### PR TITLE
feat: handle nickname coloring in MessageContent

### DIFF
--- a/src/rogu/ui/Label/index.jsx
+++ b/src/rogu/ui/Label/index.jsx
@@ -7,10 +7,7 @@ import { changeTypographyToClassName, changeColorToClassName } from './utils';
 import getStringSet from './stringSet';
 
 export default function Label({
-  className,
-  type,
-  color,
-  children,
+  children, className, color, style, type,
 }) {
   return (
     <span
@@ -20,6 +17,7 @@ export default function Label({
         type ? changeTypographyToClassName(type) : '',
         color ? changeColorToClassName(color) : '',
       ].join(' ')}
+      style={style}
     >
       {children}
     </span>
@@ -39,6 +37,7 @@ Label.propTypes = {
     PropTypes.element,
     PropTypes.any,
   ]),
+  style: PropTypes.object,
 };
 
 Label.defaultProps = {
@@ -46,6 +45,7 @@ Label.defaultProps = {
   type: '',
   color: '',
   children: null,
+  style: undefined,
 };
 
 const LabelTypography = Typography;

--- a/src/rogu/ui/MessageContent/__tests__/__snapshots__/MessageContent.spec.js.snap
+++ b/src/rogu/ui/MessageContent/__tests__/__snapshots__/MessageContent.spec.js.snap
@@ -63,6 +63,11 @@ exports[`MessageContent should do a snapshot test of the MessageContent DOM 1`] 
       >
         <span
           className="rogu-message-content__sender-name sendbird-label sendbird-label--caption-1 sendbird-label--color-onbackground-2"
+          style={
+            Object {
+              "color": "#6073E2",
+            }
+          }
         >
           Kukuh Aji Sulistyo Bangun Jaya Abadi Mangkubumi
         </span>

--- a/src/rogu/ui/MessageContent/index.tsx
+++ b/src/rogu/ui/MessageContent/index.tsx
@@ -4,7 +4,6 @@ import { GroupChannel, AdminMessage, UserMessage, FileMessage } from "sendbird";
 import Label, { LabelTypography, LabelColors } from "../Label";
 import MessageStatus from "../MessageStatus";
 import TextMessageItemBody from "../TextMessageItemBody";
-import "./index.scss";
 
 import Avatar from "../../../ui/Avatar";
 import ClientAdminMessage from "../../../ui/AdminMessage";
@@ -27,6 +26,10 @@ import {
   isSentMessage,
   isPendingMessage,
 } from "../../../utils";
+
+import { generateColorFromString } from "./utils";
+
+import "./index.scss";
 
 interface Props {
   chainBottom?: boolean;
@@ -114,8 +117,13 @@ Props): ReactElement {
             {!isByMe && !chainTop && (
               <Label
                 className="rogu-message-content__sender-name"
-                type={LabelTypography.CAPTION_1}
                 color={LabelColors.ONBACKGROUND_2}
+                style={{
+                  color: generateColorFromString(
+                    message?.sender?.nickname || ""
+                  ),
+                }}
+                type={LabelTypography.CAPTION_1}
               >
                 {getSenderName(message)}
               </Label>

--- a/src/rogu/ui/MessageContent/stories/MessageContent.stories.js
+++ b/src/rogu/ui/MessageContent/stories/MessageContent.stories.js
@@ -7,6 +7,7 @@ import { MenuRoot } from "../../../../ui/ContextMenu";
 
 import COLOR_SET from "../../../../../__mocks__/themeMock";
 import {
+  BASIC_MESSAGE,
   BASIC_MESSAGE_A_1,
   BASIC_MESSAGE_A_2,
   BASIC_MESSAGE_A_3,
@@ -110,6 +111,103 @@ export const Chaining = () => (
           isGroupChannel: () => true,
           getUnreadMemberCount: (_) => 10,
           getUndeliveredMemberCount: (_) => 0,
+        }}
+      />
+      <MenuRoot />
+    </div>
+  </SendbirdProvider>
+);
+
+export const NicknameColoring = () => (
+  <SendbirdProvider colorSet={COLOR_SET}>
+    <div style={{ backgroundColor: "#F1F7FF", padding: "1rem" }}>
+      <MessageContent
+        userId={"random-user-id"}
+        channel={{
+          isGroupChannel: () => true,
+          getUnreadMemberCount: (_) => 10,
+          getUndeliveredMemberCount: (_) => 0,
+        }}
+        message={{
+          ...BASIC_MESSAGE,
+          sender: { ...BASIC_MESSAGE.sender, nickname: "Agus Marto Wardoyo" },
+        }}
+      />
+      <MessageContent
+        userId={"random-user-id"}
+        channel={{
+          isGroupChannel: () => true,
+          getUnreadMemberCount: (_) => 10,
+          getUndeliveredMemberCount: (_) => 0,
+        }}
+        message={{
+          ...BASIC_MESSAGE,
+          sender: { ...BASIC_MESSAGE.sender, nickname: "Ekawati Hikmah" },
+        }}
+      />
+      <MessageContent
+        userId={"random-user-id"}
+        channel={{
+          isGroupChannel: () => true,
+          getUnreadMemberCount: (_) => 10,
+          getUndeliveredMemberCount: (_) => 0,
+        }}
+        message={{
+          ...BASIC_MESSAGE,
+          sender: { ...BASIC_MESSAGE.sender, nickname: "Kukuh Aji Sulistyo" },
+        }}
+      />
+      <MessageContent
+        userId={"random-user-id"}
+        channel={{
+          isGroupChannel: () => true,
+          getUnreadMemberCount: (_) => 10,
+          getUndeliveredMemberCount: (_) => 0,
+        }}
+        message={{
+          ...BASIC_MESSAGE,
+          sender: { ...BASIC_MESSAGE.sender, nickname: "Muhammad Abdul Abadi" },
+        }}
+      />
+      <MessageContent
+        userId={"random-user-id"}
+        channel={{
+          isGroupChannel: () => true,
+          getUnreadMemberCount: (_) => 10,
+          getUndeliveredMemberCount: (_) => 0,
+        }}
+        message={{
+          ...BASIC_MESSAGE,
+          sender: { ...BASIC_MESSAGE.sender, nickname: "Rashley Yeremia" },
+        }}
+      />
+
+      <MessageContent
+        userId={"random-user-id"}
+        channel={{
+          isGroupChannel: () => true,
+          getUnreadMemberCount: (_) => 10,
+          getUndeliveredMemberCount: (_) => 0,
+        }}
+        message={{
+          ...BASIC_MESSAGE,
+          sender: {
+            ...BASIC_MESSAGE.sender,
+            nickname: "Untari Wahyuni Mawardhi",
+          },
+        }}
+      />
+
+      <MessageContent
+        userId={"random-user-id"}
+        channel={{
+          isGroupChannel: () => true,
+          getUnreadMemberCount: (_) => 10,
+          getUndeliveredMemberCount: (_) => 0,
+        }}
+        message={{
+          ...BASIC_MESSAGE,
+          sender: { ...BASIC_MESSAGE.sender, nickname: "Yazid Hafizh" },
         }}
       />
       <MenuRoot />

--- a/src/rogu/ui/MessageContent/utils.ts
+++ b/src/rogu/ui/MessageContent/utils.ts
@@ -1,0 +1,26 @@
+const colorSet = {
+  "#DF4141": ["A", "B", "C", "D"],
+  "#61CE5E": ["E", "F", "G", "H"],
+  "#6073E2": ["I", "J", "K", "L"],
+  "#F89825": ["M", "N", "O", "P"],
+  "#2EB5C0": ["Q", "R", "S", "T"],
+  "#BB58D0": ["U", "V", "W", "X"],
+  "#00A5FF": ["Y", "Z"],
+};
+
+export const generateColorFromString = (str: string): string => {
+  const firstChar = str[0] || "";
+  const normalizedFirstChar = firstChar.toUpperCase();
+
+  let color = "inherit";
+  for (const [hex, chars] of Object.entries(colorSet)) {
+    if (chars.includes(normalizedFirstChar)) {
+      color = hex;
+      break;
+    }
+  }
+
+  return color;
+};
+
+export default generateColorFromString;


### PR DESCRIPTION
> This project is a forked version of the [Sendbird UI Kit](https://github.com/sendbird/sendbird-uikit-react) to match with the Ruangguru's internal requirements. Therefore, it is not yet set up to accept pull requests from external contributors. But you can always freely create a forked version from this repository to match your own requirements.

## Related Issue

[RKLS-914](https://ruanggguru.atlassian.net/browse/RKLS-914)

## Description Of Changes

Handle nickname coloring based on its first letter:

- A-D = `#DF4141`
- E-H = `#61CE5E`
- I-L = `#6073E2`
- M-P = `#F89825`
- Q-T = `#2EB5C0`
- U-Z = `#BB58D0`
- Y-Z = `#00A5FF`

Demo:
![image](https://user-images.githubusercontent.com/24476578/137473397-ae9178f7-5e82-4afe-a5c1-eb060696e73a.png)



