### PR TITLE
fix(component): make the message item body to be full-width related to its container

### DIFF
--- a/src/rogu/ui/AssignmentMessageItemBody/index.scss
+++ b/src/rogu/ui/AssignmentMessageItemBody/index.scss
@@ -3,14 +3,12 @@
 .rogu-assignment-message-item-body {
   position: relative;
   display: inline-block;
-  // TODO: Change fixing width and height lengths
   width: 100%;
   min-width: 200px;
-  max-width: 400px;
 
   .rogu-assignment-message-item-body__text-bubble {
     position: relative;
-    padding: 8px 12px;
+    padding: 8px;
     box-sizing: border-box;
     border-radius: 16px 16px 0 0;
     word-break: break-all;
@@ -21,7 +19,7 @@
     overflow: hidden;
     display: flex;
     align-items: center;
-    padding: 12px;
+    padding: 8px;
     border-radius: 4px;
     cursor: pointer;
     z-index: 10;

--- a/src/rogu/ui/FileViewer/__tests__/__snapshots__/FileViewer.spec.js.snap
+++ b/src/rogu/ui/FileViewer/__tests__/__snapshots__/FileViewer.spec.js.snap
@@ -168,7 +168,7 @@ exports[`FileViewer should do a snapshot test of the FileViewer DOM 1`] = `
       tabIndex="0"
     />
     <div
-      className=" rogu-text-message-item-body  rogu-text-message-item-body--incoming viewer-mode  "
+      className=" rogu-text-message-item-body  rogu-text-message-item-body--incoming rogu-text-message-item-body--viewer-mode  "
     >
       <div
         className="rogu-text-message-item-body__inner"

--- a/src/rogu/ui/MaterialMessageItemBody/index.scss
+++ b/src/rogu/ui/MaterialMessageItemBody/index.scss
@@ -3,10 +3,8 @@
 .rogu-material-message-item-body {
   position: relative;
   display: inline-block;
-  box-sizing: content-box;
   width: 100%;
   min-width: 200px;
-  max-width: 400px;
 
   .rogu-material-message-text {
     white-space: pre-wrap;
@@ -26,7 +24,7 @@
     overflow: hidden;
     display: flex;
     align-items: center;
-    padding: 12px;
+    padding: 8px;
     border-radius: 4px;
     cursor: pointer;
     z-index: 10;

--- a/src/rogu/ui/MessageContent/__tests__/__snapshots__/MessageContent.spec.js.snap
+++ b/src/rogu/ui/MessageContent/__tests__/__snapshots__/MessageContent.spec.js.snap
@@ -9,8 +9,8 @@ exports[`MessageContent should do a snapshot test of the MessageContent DOM 1`] 
     role="button"
     style={
       Object {
-        "height": "2rem",
-        "width": "2rem",
+        "height": "32px",
+        "width": "32px",
       }
     }
     tabIndex={0}
@@ -19,9 +19,9 @@ exports[`MessageContent should do a snapshot test of the MessageContent DOM 1`] 
       className="sendbird-avatar-img sendbird-image-renderer"
       style={
         Object {
-          "height": "2rem",
+          "height": "32px",
           "maxWidth": "400px",
-          "minWidth": "2rem",
+          "minWidth": "32px",
           "width": "100%",
         }
       }
@@ -35,9 +35,9 @@ exports[`MessageContent should do a snapshot test of the MessageContent DOM 1`] 
             "backgroundRepeat": "no-repeat",
             "backgroundSize": "cover",
             "borderRadius": null,
-            "height": "2rem",
+            "height": "32px",
             "maxWidth": "400px",
-            "minWidth": "2rem",
+            "minWidth": "32px",
             "position": "absolute",
             "width": "100%",
           }
@@ -72,7 +72,7 @@ exports[`MessageContent should do a snapshot test of the MessageContent DOM 1`] 
           Kukuh Aji Sulistyo Bangun Jaya Abadi Mangkubumi
         </span>
         <div
-          className="rogu-message-content__menu rogu-message-item-menu"
+          className="rogu-message-content-menu__normal-menu rogu-message-item-menu"
         >
           <div
             className="sendbird-context-menu"

--- a/src/rogu/ui/MessageContent/__tests__/__snapshots__/MessageContent.spec.js.snap
+++ b/src/rogu/ui/MessageContent/__tests__/__snapshots__/MessageContent.spec.js.snap
@@ -72,7 +72,7 @@ exports[`MessageContent should do a snapshot test of the MessageContent DOM 1`] 
           Kukuh Aji Sulistyo Bangun Jaya Abadi Mangkubumi
         </span>
         <div
-          className="rogu-message-content-menu__normal-menu rogu-message-item-menu"
+          className="rogu-message-content__menu rogu-message-item-menu"
         >
           <div
             className="sendbird-context-menu"
@@ -124,7 +124,7 @@ exports[`MessageContent should do a snapshot test of the MessageContent DOM 1`] 
         className="rogu-message-content__bubble__body"
       >
         <div
-          className="rogu-message-content__buble__body-text"
+          className="rogu-message-content__bubble__body__inner"
         >
           <div
             className=" rogu-text-message-item-body  rogu-text-message-item-body--incoming   "

--- a/src/rogu/ui/MessageContent/index.scss
+++ b/src/rogu/ui/MessageContent/index.scss
@@ -1,9 +1,9 @@
-@import '../../../styles/variables';
+@import "../../../styles/variables";
 
-$borderRadius: 0.5rem;
-$bubbleCaretSize: 0.5rem;
-$avatarSpacing: 0.5rem;
-$avatarSize: 2rem;
+$borderRadius: 8px;
+$bubbleCaretSize: 8px;
+$avatarSpacing: 8px;
+$avatarSize: 32px;
 
 .rogu-message-content {
   position: relative;
@@ -11,7 +11,7 @@ $avatarSize: 2rem;
   flex-direction: row;
   width: 100%;
   height: 100%;
-  margin-bottom: 1rem;
+  margin-bottom: 16px;
 
   @include themed() {
     color: t(on-bg-1);
@@ -29,16 +29,16 @@ $avatarSize: 2rem;
     flex-direction: column;
     align-items: flex-end;
     position: relative;
-    max-width: 21rem;
+    max-width: 548px;
 
     .rogu-message-content__menu {
-      margin-left: 0.25rem;
+      margin-left: 4px;
     }
 
     .rogu-message-content__bubble {
       display: flex;
       flex-direction: column;
-      padding: 0.75rem;
+      padding: 12px;
       border-top-left-radius: $borderRadius;
       border-top-right-radius: $borderRadius;
       border-bottom-left-radius: $borderRadius;
@@ -49,7 +49,7 @@ $avatarSize: 2rem;
         display: flex;
         flex-wrap: nowrap;
         justify-content: space-between;
-        margin-bottom: 0.25rem;
+        margin-bottom: 4px;
         align-items: center;
 
         .rogu-message-content__sender-name {
@@ -62,9 +62,9 @@ $avatarSize: 2rem;
         }
 
         .rogu-message-content__operator-label {
-          margin-left: 0.5rem;
-          padding: 0.25rem 0.75rem;
-          border-radius: 0.25rem;
+          margin-left: 8px;
+          padding: 4px 12px;
+          border-radius: 4px;
           white-space: nowrap;
 
           @include themed() {
@@ -79,7 +79,7 @@ $avatarSize: 2rem;
       }
 
       &::before {
-        content: '';
+        content: "";
         width: 0;
         height: 0;
         border-style: solid;
@@ -97,7 +97,7 @@ $avatarSize: 2rem;
     }
 
     .rogu-message-content__misc {
-      margin-top: 0.25rem;
+      margin-top: 4px;
     }
   }
 
@@ -153,7 +153,7 @@ $avatarSize: 2rem;
   }
 
   &.rogu-message-content--chain-bottom {
-    margin-bottom: 0.5rem;
+    margin-bottom: 8px;
   }
 
   &.rogu-message-content--chain-top {

--- a/src/rogu/ui/MessageContent/index.scss
+++ b/src/rogu/ui/MessageContent/index.scss
@@ -1,4 +1,4 @@
-@import "../../../styles/variables";
+@import '../../../styles/variables';
 
 $borderRadius: 0.5rem;
 $bubbleCaretSize: 0.5rem;
@@ -31,10 +31,14 @@ $avatarSize: 2rem;
     position: relative;
     max-width: 21rem;
 
+    .rogu-message-content__menu {
+      margin-left: 0.25rem;
+    }
+
     .rogu-message-content__bubble {
       display: flex;
       flex-direction: column;
-      padding: 0.75rem 0.5rem 0.75rem 0.75rem;
+      padding: 0.75rem;
       border-top-left-radius: $borderRadius;
       border-top-right-radius: $borderRadius;
       border-bottom-left-radius: $borderRadius;
@@ -75,7 +79,7 @@ $avatarSize: 2rem;
       }
 
       &::before {
-        content: "";
+        content: '';
         width: 0;
         height: 0;
         border-style: solid;
@@ -86,8 +90,8 @@ $avatarSize: 2rem;
       .rogu-message-content__bubble__body {
         display: flex;
 
-        .rogu-message-content__buble__body-text {
-          margin-right: 0.25rem;
+        .rogu-message-content__bubble__body__inner {
+          width: 100%;
         }
       }
     }

--- a/src/rogu/ui/MessageContent/index.tsx
+++ b/src/rogu/ui/MessageContent/index.tsx
@@ -120,8 +120,8 @@ Props): ReactElement {
           className="rogu-message-content__avatar"
           src={message?.sender?.profileUrl || ""}
           ref={avatarRef}
-          height="2rem"
-          width="2rem"
+          height="32px"
+          width="32px"
         />
       )}
 
@@ -225,20 +225,6 @@ Props): ReactElement {
                 <UnknownMessageItemBody message={message} isByMe={isByMe} />
               )}
             </div>
-            {((!isByMe && chainTop) || isByMe) && (
-              <MessageItemMenu
-                className="rogu-message-content__menu"
-                channel={channel}
-                message={message as UserMessage | FileMessage}
-                isByMe={isByMe}
-                disabled={disabled}
-                showEdit={showEdit}
-                showRemove={showRemove}
-                resendMessage={resendMessage}
-                showFileViewer={showFileViewer}
-              />
-            )}
-
             {((!isByMe && chainTop) || isByMe) && (
               <MessageItemMenu
                 className="rogu-message-content__menu"

--- a/src/rogu/ui/MessageContent/index.tsx
+++ b/src/rogu/ui/MessageContent/index.tsx
@@ -31,11 +31,7 @@ import {
   CoreMessageType,
 } from "../../../utils";
 
-<<<<<<< HEAD
 import { isAssignmentMessage, isMaterialMessage } from '../../utils';
-=======
-import { isAssignmentMessage, isMaterialMessage } from "../../utils";
->>>>>>> 8e8ea34 (fix(component): omit max-width from the message item body)
 import AssignmentMessageItemBody from "../AssignmentMessageItemBody";
 import MaterialMessageItemBody from "../MaterialMessageItemBody";
 import { generateColorFromString } from "./utils";
@@ -135,10 +131,6 @@ export default function MessageContent({
           <div className="rogu-message-content__bubble__header">
             {!isByMe && !chainTop && (
               <>
-<<<<<<< HEAD
-=======
-                {/* Sender's name */}
->>>>>>> 8e8ea34 (fix(component): omit max-width from the message item body)
                 <Label
                   className="rogu-message-content__sender-name"
                   color={LabelColors.ONBACKGROUND_2}
@@ -151,7 +143,6 @@ export default function MessageContent({
                 >
                   {getSenderName(message)}
                 </Label>
-<<<<<<< HEAD
                 {/* Teacher label */}
                 {isOperatorMessage && !chainTop && (
                   <Label
@@ -231,19 +222,6 @@ export default function MessageContent({
             </div>
             {
               ((!isByMe && chainTop) || isByMe) && (
-=======
-
-                {/* Teacher label */}
-                {isOperatorMessage && !chainTop && (
-                  <Label
-                    className="rogu-message-content__operator-label"
-                    type={LabelTypography.CAPTION_3}
-                  >
-                    {stringSet.LABEL__OPERATOR}
-                  </Label>
-                )}
-
->>>>>>> 8e8ea34 (fix(component): omit max-width from the message item body)
                 <MessageItemMenu
                   className="rogu-message-content__menu"
                   channel={channel}
@@ -253,73 +231,11 @@ export default function MessageContent({
                   showEdit={showEdit}
                   showRemove={showRemove}
                   resendMessage={resendMessage}
-<<<<<<< HEAD
                   showFileViewer={showFileViewer} />
 
               )
             }
 
-=======
-                  showFileViewer={showFileViewer}
-                />
-              </>
-            )}
-          </div>
-
-          <div className="rogu-message-content__bubble__body">
-            <div className="rogu-message-content__bubble__body__inner">
-              {/* Message content */}
-              {isTextMessage(message as UserMessage) && (
-                <TextMessageItemBody
-                  isByMe={isByMe}
-                  message={(message as UserMessage).message}
-                />
-              )}
-              {isOGMessage(message as UserMessage) && (
-                <OGMessageItemBody
-                  message={message as UserMessage}
-                  isByMe={isByMe}
-                />
-              )}
-              {isAssignmentMessage(message.customType) && (
-                <AssignmentMessageItemBody
-                  message={message as UserMessage}
-                  isByMe={isByMe}
-                />
-              )}
-              {isMaterialMessage(message.customType) && (
-                <MaterialMessageItemBody
-                  message={message as UserMessage}
-                  isByMe={isByMe}
-                />
-              )}
-              {getUIKitMessageType(message as FileMessage) ===
-                messageTypes.FILE && (
-                <FileMessageItemBody
-                  message={message as FileMessage}
-                  isByMe={isByMe}
-                />
-              )}
-              {isThumbnailMessage(message as FileMessage) && (
-                <>
-                  <ThumbnailMessageItemBody
-                    message={message as FileMessage}
-                    isByMe={isByMe}
-                    showFileViewer={showFileViewer}
-                  />
-                  <TextMessageItemBody
-                    isByMe={isByMe}
-                    mode="thumbnailCaption"
-                    message={(message as FileMessage)?.name}
-                  />
-                </>
-              )}
-              {getUIKitMessageType(message as FileMessage) ===
-                messageTypes.UNKNOWN && (
-                <UnknownMessageItemBody message={message} isByMe={isByMe} />
-              )}
-            </div>
->>>>>>> 8e8ea34 (fix(component): omit max-width from the message item body)
 
             {((!isByMe && chainTop) || isByMe) && (
               <MessageItemMenu
@@ -335,11 +251,8 @@ export default function MessageContent({
               />
             )}
           </div>
-<<<<<<< HEAD
 
 
-=======
->>>>>>> 8e8ea34 (fix(component): omit max-width from the message item body)
         </div>
 
         {/* Message status */}

--- a/src/rogu/ui/MessageContent/index.tsx
+++ b/src/rogu/ui/MessageContent/index.tsx
@@ -31,7 +31,7 @@ import {
   CoreMessageType,
 } from "../../../utils";
 
-import { isAssignmentMessage, isMaterialMessage } from '../../utils';
+import { isAssignmentMessage, isMaterialMessage } from "../../utils";
 import AssignmentMessageItemBody from "../AssignmentMessageItemBody";
 import MaterialMessageItemBody from "../MaterialMessageItemBody";
 import { generateColorFromString } from "./utils";
@@ -78,8 +78,8 @@ export default function MessageContent({
   resendMessage,
   disabled = false,
 }: // showRemove,
-  // toggleReaction,
-  Props): ReactElement {
+// toggleReaction,
+Props): ReactElement {
   const { stringSet } = useContext(LocalizationContext);
   const messageTypes = getUIKitMessageTypes();
   const avatarRef = useRef(null);
@@ -169,12 +169,12 @@ export default function MessageContent({
           </div>
 
           <div className="rogu-message-content__bubble__body">
-            <div className="rogu-message-content__buble__body-text">
+            <div className="rogu-message-content__bubble__body__inner">
               {/* Message content */}
               {isTextMessage(message as UserMessage) && (
                 <TextMessageItemBody
                   isByMe={isByMe}
-                  message={message?.message}
+                  message={(message as UserMessage)?.message}
                 />
               )}
               {isOGMessage(message as UserMessage) && (
@@ -183,59 +183,61 @@ export default function MessageContent({
                   isByMe={isByMe}
                 />
               )}
-              {
-                isAssignmentMessage(message.customType) && (
-                  <AssignmentMessageItemBody message={message as UserMessage} isByMe={isByMe} />
-                )
-              }
-              {
-                isMaterialMessage(message.customType) && (
-                  <MaterialMessageItemBody message={message as UserMessage} isByMe={isByMe} />
-                )
-              }
+              {isAssignmentMessage(message.customType) && (
+                <AssignmentMessageItemBody
+                  message={message as UserMessage}
+                  isByMe={isByMe}
+                />
+              )}
+              {isMaterialMessage(message.customType) && (
+                <MaterialMessageItemBody
+                  message={message as UserMessage}
+                  isByMe={isByMe}
+                />
+              )}
               {getUIKitMessageType(message as FileMessage) ===
                 messageTypes.FILE && (
-                  <FileMessageItemBody
-                    message={message as FileMessage}
-                    isByMe={isByMe}
-                  />
-                )}
+                <FileMessageItemBody
+                  message={message as FileMessage}
+                  isByMe={isByMe}
+                />
+              )}
               {isThumbnailMessage(message as FileMessage) && (
                 <>
                   <ThumbnailMessageItemBody
                     message={message as FileMessage}
                     isByMe={isByMe}
                     showFileViewer={showFileViewer}
-                    isClickable={getOutgoingMessageState(channel, message) === OutgoingMessageStates.SENT}
+                    isClickable={
+                      getOutgoingMessageState(channel, message) ===
+                      OutgoingMessageStates.SENT
+                    }
                   />
                   <TextMessageItemBody
                     isByMe={isByMe}
                     mode="thumbnailCaption"
-                    message={message?.name}
+                    message={(message as FileMessage).name}
                   />
                 </>
               )}
               {getUIKitMessageType(message as FileMessage) ===
                 messageTypes.UNKNOWN && (
-                  <UnknownMessageItemBody message={message} isByMe={isByMe} />
-                )}
+                <UnknownMessageItemBody message={message} isByMe={isByMe} />
+              )}
             </div>
-            {
-              ((!isByMe && chainTop) || isByMe) && (
-                <MessageItemMenu
-                  className="rogu-message-content__menu"
-                  channel={channel}
-                  message={message as UserMessage | FileMessage}
-                  isByMe={isByMe}
-                  disabled={disabled}
-                  showEdit={showEdit}
-                  showRemove={showRemove}
-                  resendMessage={resendMessage}
-                  showFileViewer={showFileViewer} />
-
-              )
-            }
-
+            {((!isByMe && chainTop) || isByMe) && (
+              <MessageItemMenu
+                className="rogu-message-content__menu"
+                channel={channel}
+                message={message as UserMessage | FileMessage}
+                isByMe={isByMe}
+                disabled={disabled}
+                showEdit={showEdit}
+                showRemove={showRemove}
+                resendMessage={resendMessage}
+                showFileViewer={showFileViewer}
+              />
+            )}
 
             {((!isByMe && chainTop) || isByMe) && (
               <MessageItemMenu
@@ -251,8 +253,6 @@ export default function MessageContent({
               />
             )}
           </div>
-
-
         </div>
 
         {/* Message status */}

--- a/src/rogu/ui/MessageContent/index.tsx
+++ b/src/rogu/ui/MessageContent/index.tsx
@@ -31,7 +31,11 @@ import {
   CoreMessageType,
 } from "../../../utils";
 
+<<<<<<< HEAD
 import { isAssignmentMessage, isMaterialMessage } from '../../utils';
+=======
+import { isAssignmentMessage, isMaterialMessage } from "../../utils";
+>>>>>>> 8e8ea34 (fix(component): omit max-width from the message item body)
 import AssignmentMessageItemBody from "../AssignmentMessageItemBody";
 import MaterialMessageItemBody from "../MaterialMessageItemBody";
 import { generateColorFromString } from "./utils";
@@ -84,7 +88,6 @@ export default function MessageContent({
   const messageTypes = getUIKitMessageTypes();
   const avatarRef = useRef(null);
 
-
   const isByMe: boolean =
     isPendingMessage(channel, message as UserMessage | FileMessage) ||
     !isSentMessage(channel, message as UserMessage | FileMessage) ||
@@ -104,7 +107,6 @@ export default function MessageContent({
   if (message?.isAdminMessage?.() || message?.messageType === "admin") {
     return <ClientAdminMessage message={message} />;
   }
-
 
   return (
     <div
@@ -131,9 +133,12 @@ export default function MessageContent({
         {/* Bubble wrapper */}
         <div className="rogu-message-content__bubble">
           <div className="rogu-message-content__bubble__header">
-            {/* Sender's name */}
             {!isByMe && !chainTop && (
               <>
+<<<<<<< HEAD
+=======
+                {/* Sender's name */}
+>>>>>>> 8e8ea34 (fix(component): omit max-width from the message item body)
                 <Label
                   className="rogu-message-content__sender-name"
                   color={LabelColors.ONBACKGROUND_2}
@@ -146,6 +151,7 @@ export default function MessageContent({
                 >
                   {getSenderName(message)}
                 </Label>
+<<<<<<< HEAD
                 {/* Teacher label */}
                 {isOperatorMessage && !chainTop && (
                   <Label
@@ -225,8 +231,21 @@ export default function MessageContent({
             </div>
             {
               ((!isByMe && chainTop) || isByMe) && (
+=======
+
+                {/* Teacher label */}
+                {isOperatorMessage && !chainTop && (
+                  <Label
+                    className="rogu-message-content__operator-label"
+                    type={LabelTypography.CAPTION_3}
+                  >
+                    {stringSet.LABEL__OPERATOR}
+                  </Label>
+                )}
+
+>>>>>>> 8e8ea34 (fix(component): omit max-width from the message item body)
                 <MessageItemMenu
-                  className="rogu-message-content-menu__normal-menu"
+                  className="rogu-message-content__menu"
                   channel={channel}
                   message={message as UserMessage | FileMessage}
                   isByMe={isByMe}
@@ -234,15 +253,93 @@ export default function MessageContent({
                   showEdit={showEdit}
                   showRemove={showRemove}
                   resendMessage={resendMessage}
+<<<<<<< HEAD
                   showFileViewer={showFileViewer} />
 
               )
             }
 
-
+=======
+                  showFileViewer={showFileViewer}
+                />
+              </>
+            )}
           </div>
 
+          <div className="rogu-message-content__bubble__body">
+            <div className="rogu-message-content__bubble__body__inner">
+              {/* Message content */}
+              {isTextMessage(message as UserMessage) && (
+                <TextMessageItemBody
+                  isByMe={isByMe}
+                  message={(message as UserMessage).message}
+                />
+              )}
+              {isOGMessage(message as UserMessage) && (
+                <OGMessageItemBody
+                  message={message as UserMessage}
+                  isByMe={isByMe}
+                />
+              )}
+              {isAssignmentMessage(message.customType) && (
+                <AssignmentMessageItemBody
+                  message={message as UserMessage}
+                  isByMe={isByMe}
+                />
+              )}
+              {isMaterialMessage(message.customType) && (
+                <MaterialMessageItemBody
+                  message={message as UserMessage}
+                  isByMe={isByMe}
+                />
+              )}
+              {getUIKitMessageType(message as FileMessage) ===
+                messageTypes.FILE && (
+                <FileMessageItemBody
+                  message={message as FileMessage}
+                  isByMe={isByMe}
+                />
+              )}
+              {isThumbnailMessage(message as FileMessage) && (
+                <>
+                  <ThumbnailMessageItemBody
+                    message={message as FileMessage}
+                    isByMe={isByMe}
+                    showFileViewer={showFileViewer}
+                  />
+                  <TextMessageItemBody
+                    isByMe={isByMe}
+                    mode="thumbnailCaption"
+                    message={(message as FileMessage)?.name}
+                  />
+                </>
+              )}
+              {getUIKitMessageType(message as FileMessage) ===
+                messageTypes.UNKNOWN && (
+                <UnknownMessageItemBody message={message} isByMe={isByMe} />
+              )}
+            </div>
+>>>>>>> 8e8ea34 (fix(component): omit max-width from the message item body)
 
+            {((!isByMe && chainTop) || isByMe) && (
+              <MessageItemMenu
+                className="rogu-message-content__menu"
+                channel={channel}
+                message={message as UserMessage | FileMessage}
+                isByMe={isByMe}
+                disabled={disabled}
+                showEdit={showEdit}
+                showRemove={showRemove}
+                resendMessage={resendMessage}
+                showFileViewer={showFileViewer}
+              />
+            )}
+          </div>
+<<<<<<< HEAD
+
+
+=======
+>>>>>>> 8e8ea34 (fix(component): omit max-width from the message item body)
         </div>
 
         {/* Message status */}

--- a/src/rogu/ui/ThumbnailMessageItemBody/index.tsx
+++ b/src/rogu/ui/ThumbnailMessageItemBody/index.tsx
@@ -1,10 +1,10 @@
-import React, { ReactElement } from 'react';
-import { FileMessage } from 'sendbird';
-import './index.scss';
+import React, { ReactElement } from "react";
+import { FileMessage } from "sendbird";
+import "./index.scss";
 
-import Icon, { IconTypes, IconColors } from '../Icon';
-import ImageRenderer from '../ImageRenderer';
-import { getClassName, isGifMessage, isVideoMessage } from '../../../utils';
+import Icon, { IconTypes, IconColors } from "../Icon";
+import ImageRenderer from "../ImageRenderer";
+import { getClassName, isGifMessage, isVideoMessage } from "../../../utils";
 
 interface Props {
   className?: string | Array<string>;
@@ -12,7 +12,7 @@ interface Props {
   isByMe?: boolean;
   mouseHover?: boolean;
   showFileViewer?: (bool: boolean) => void;
-  isClickable: boolean,
+  isClickable: boolean;
 }
 
 export default function ThumbnailMessageItemBody({
@@ -24,18 +24,20 @@ export default function ThumbnailMessageItemBody({
   isClickable = true,
 }: Props): ReactElement {
   const { thumbnails = [] } = message;
-  const thumbnailUrl: string = thumbnails.length > 0 ? thumbnails[0]?.url : '';
+  const thumbnailUrl: string = thumbnails.length > 0 ? thumbnails[0]?.url : "";
 
   return (
     <div
       className={getClassName([
         className,
-        'rogu-thumbnail-message-item-body',
-        isByMe ? 'outgoing' : 'incoming',
-        mouseHover ? 'mouse-hover' : '',
-        message?.reactions?.length > 0 ? 'reactions' : '',
+        "rogu-thumbnail-message-item-body",
+        isByMe ? "outgoing" : "incoming",
+        mouseHover ? "mouse-hover" : "",
+        message?.reactions?.length > 0 ? "reactions" : "",
       ])}
-      onClick={isClickable ? () => showFileViewer(true) : () => { }}
+      onClick={() => {
+        if (isClickable) showFileViewer(true);
+      }}
     >
       <ImageRenderer
         className="rogu-thumbnail-message-item-body__thumbnail"
@@ -50,7 +52,9 @@ export default function ThumbnailMessageItemBody({
           >
             <div className="rogu-thumbnail-message-item-body__placeholder__icon">
               <Icon
-                type={isVideoMessage(message) ? IconTypes.PLAY : IconTypes.PHOTO}
+                type={
+                  isVideoMessage(message) ? IconTypes.PLAY : IconTypes.PHOTO
+                }
                 fillColor={IconColors.ON_BACKGROUND_2}
                 width="34px"
                 height="34px"
@@ -59,7 +63,7 @@ export default function ThumbnailMessageItemBody({
           </div>
         )}
       />
-      {(isVideoMessage(message) && !thumbnailUrl) && (
+      {isVideoMessage(message) && !thumbnailUrl && (
         <video className="rogu-thumbnail-message-item-body__video">
           <source src={message?.url} type={message?.type} />
         </video>

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -87,7 +87,7 @@ const SendingMessageStatus: SendingMessageStatus = {
   PENDING: "pending",
 };
 
-export interface OutgoingMessageStates {
+interface OutgoingMessageStates {
   NONE: "NONE";
   PENDING: "PENDING";
   SENT: "SENT";


### PR DESCRIPTION
> This project is a forked version of the [Sendbird UI Kit](https://github.com/sendbird/sendbird-uikit-react) to match with the Ruangguru's internal requirements. Therefore, it is not yet set up to accept pull requests from external contributors. But you can always freely create a forked version from this repository to match your own requirements.

## Related Issue

-

## Description Of Changes

- Make the message item body to be full-width (relative to its container)
   **Before**:

   <img width="519" alt="Screen Shot 2021-10-28 at 08 21 57" src="https://user-images.githubusercontent.com/24476578/139170139-cb8e641b-df9d-48da-a486-2b575ac34646.png">
   <img width="514" alt="Screen Shot 2021-10-28 at 08 21 43" src="https://user-images.githubusercontent.com/24476578/139170142-7f40792a-e710-4b23-8d0d-0a07d639c724.png">
   
   **After**:
   <img width="489" alt="Screen Shot 2021-10-28 at 08 37 49" src="https://user-images.githubusercontent.com/24476578/139171404-6f7625a2-40c8-44b8-a4be-495ccf83ddab.png">
   <img width="501" alt="Screen Shot 2021-10-28 at 08 37 40" src="https://user-images.githubusercontent.com/24476578/139171409-d9d61b74-f700-4012-9f79-f943bd17d43f.png">
   
- Fix spacing of menu item



