### PR TITLE
fix: prevent thumbnail click behaviour if the message is not sent yet

### DIFF
--- a/src/rogu/ui/MessageContent/index.tsx
+++ b/src/rogu/ui/MessageContent/index.tsx
@@ -12,6 +12,7 @@ import ThumbnailMessageItemBody from "../ThumbnailMessageItemBody";
 import UnknownMessageItemBody from "../../../ui/UnknownMessageItemBody";
 
 import { LocalizationContext } from "../../../lib/LocalizationContext";
+import { OutgoingMessageStates } from "../../../utils/index";
 
 import {
   getClassName,
@@ -30,7 +31,7 @@ import {
   CoreMessageType,
 } from "../../../utils";
 
-import {isAssignmentMessage, isMaterialMessage} from '../../utils';
+import { isAssignmentMessage, isMaterialMessage } from '../../utils';
 import AssignmentMessageItemBody from "../AssignmentMessageItemBody";
 import MaterialMessageItemBody from "../MaterialMessageItemBody";
 import { generateColorFromString } from "./utils";
@@ -75,10 +76,10 @@ export default function MessageContent({
   showFileViewer,
   showRemove,
   resendMessage,
-  disabled=false,
+  disabled = false,
 }: // showRemove,
-// toggleReaction,
-Props): ReactElement {
+  // toggleReaction,
+  Props): ReactElement {
   const { stringSet } = useContext(LocalizationContext);
   const messageTypes = getUIKitMessageTypes();
   const avatarRef = useRef(null);
@@ -114,7 +115,7 @@ Props): ReactElement {
         chainBottomClassName,
         chainTopClassName,
       ])}
-    >      
+    >
       {/* Profile picture */}
       {!isByMe && !chainTop && (
         <Avatar
@@ -132,93 +133,95 @@ Props): ReactElement {
           <div className="rogu-message-content__bubble__header">
             {/* Sender's name */}
             {!isByMe && !chainTop && (
-            <>
-              <Label
-                className="rogu-message-content__sender-name"
-                color={LabelColors.ONBACKGROUND_2}
-                style={{
-                  color: generateColorFromString(
-                    message?.sender?.nickname || ""
-                  ),
-                }}
-                type={LabelTypography.CAPTION_1}
-              >
-                {getSenderName(message)}                
-              </Label>
-              {/* Teacher label */}
-              {isOperatorMessage && !chainTop && (
+              <>
                 <Label
-                  className="rogu-message-content__operator-label"
-                  type={LabelTypography.CAPTION_3}
+                  className="rogu-message-content__sender-name"
+                  color={LabelColors.ONBACKGROUND_2}
+                  style={{
+                    color: generateColorFromString(
+                      message?.sender?.nickname || ""
+                    ),
+                  }}
+                  type={LabelTypography.CAPTION_1}
                 >
-                  {stringSet.LABEL__OPERATOR}
+                  {getSenderName(message)}
                 </Label>
-              )}
+                {/* Teacher label */}
+                {isOperatorMessage && !chainTop && (
+                  <Label
+                    className="rogu-message-content__operator-label"
+                    type={LabelTypography.CAPTION_3}
+                  >
+                    {stringSet.LABEL__OPERATOR}
+                  </Label>
+                )}
 
-              <MessageItemMenu
-              className="rogu-message-content-menu__normal-menu"
-              channel={channel}
-              message={message as UserMessage | FileMessage}
-              isByMe={isByMe}
-              disabled={disabled}
-              showEdit={showEdit}
-              showRemove={showRemove}
-              resendMessage={resendMessage}
-              showFileViewer={showFileViewer}/>
-            </>
+                <MessageItemMenu
+                  className="rogu-message-content-menu__normal-menu"
+                  channel={channel}
+                  message={message as UserMessage | FileMessage}
+                  isByMe={isByMe}
+                  disabled={disabled}
+                  showEdit={showEdit}
+                  showRemove={showRemove}
+                  resendMessage={resendMessage}
+                  showFileViewer={showFileViewer}
+                />
+              </>
             )}
           </div>
 
           <div className="rogu-message-content__bubble__body">
             <div className="rogu-message-content__buble__body-text">
-            {/* Message content */}
-            {isTextMessage(message as UserMessage) && (
-              <TextMessageItemBody
-                isByMe={isByMe}
-                message={message?.message}
-              />
-            )}
-            {isOGMessage(message as UserMessage) && (
-              <OGMessageItemBody
-                message={message as UserMessage}
-                isByMe={isByMe}
-              />
-            )}
-            {
-              isAssignmentMessage(message.customType) && (
-                <AssignmentMessageItemBody message={message as UserMessage} isByMe={isByMe} />
-              )
-            }
-            {
-              isMaterialMessage(message.customType) && (
-                <MaterialMessageItemBody message={message as UserMessage} isByMe={isByMe} />
-              )
-            }
-            {getUIKitMessageType(message as FileMessage) ===
-              messageTypes.FILE && (
-              <FileMessageItemBody
-                message={message as FileMessage}
-                isByMe={isByMe}
-              />
-            )}
-            {isThumbnailMessage(message as FileMessage) && (
-              <>
-                <ThumbnailMessageItemBody
-                  message={message as FileMessage}
-                  isByMe={isByMe}
-                  showFileViewer={showFileViewer}
-                />
+              {/* Message content */}
+              {isTextMessage(message as UserMessage) && (
                 <TextMessageItemBody
                   isByMe={isByMe}
-                  mode="thumbnailCaption"
-                  message={message?.name}
+                  message={message?.message}
                 />
-              </>
-            )}
-            {getUIKitMessageType(message as FileMessage) ===
-              messageTypes.UNKNOWN && (
-              <UnknownMessageItemBody message={message} isByMe={isByMe} />
-            )}
+              )}
+              {isOGMessage(message as UserMessage) && (
+                <OGMessageItemBody
+                  message={message as UserMessage}
+                  isByMe={isByMe}
+                />
+              )}
+              {
+                isAssignmentMessage(message.customType) && (
+                  <AssignmentMessageItemBody message={message as UserMessage} isByMe={isByMe} />
+                )
+              }
+              {
+                isMaterialMessage(message.customType) && (
+                  <MaterialMessageItemBody message={message as UserMessage} isByMe={isByMe} />
+                )
+              }
+              {getUIKitMessageType(message as FileMessage) ===
+                messageTypes.FILE && (
+                  <FileMessageItemBody
+                    message={message as FileMessage}
+                    isByMe={isByMe}
+                  />
+                )}
+              {isThumbnailMessage(message as FileMessage) && (
+                <>
+                  <ThumbnailMessageItemBody
+                    message={message as FileMessage}
+                    isByMe={isByMe}
+                    showFileViewer={showFileViewer}
+                    isClickable={getOutgoingMessageState(channel, message) !== OutgoingMessageStates.PENDING}
+                  />
+                  <TextMessageItemBody
+                    isByMe={isByMe}
+                    mode="thumbnailCaption"
+                    message={message?.name}
+                  />
+                </>
+              )}
+              {getUIKitMessageType(message as FileMessage) ===
+                messageTypes.UNKNOWN && (
+                  <UnknownMessageItemBody message={message} isByMe={isByMe} />
+                )}
             </div>
             {
               ((!isByMe && chainTop) || isByMe) && (
@@ -231,15 +234,15 @@ Props): ReactElement {
                   showEdit={showEdit}
                   showRemove={showRemove}
                   resendMessage={resendMessage}
-                  showFileViewer={showFileViewer}/>
+                  showFileViewer={showFileViewer} />
 
               )
             }
-            
+
 
           </div>
-          
-          
+
+
         </div>
 
         {/* Message status */}

--- a/src/rogu/ui/MessageContent/index.tsx
+++ b/src/rogu/ui/MessageContent/index.tsx
@@ -209,7 +209,7 @@ export default function MessageContent({
                     message={message as FileMessage}
                     isByMe={isByMe}
                     showFileViewer={showFileViewer}
-                    isClickable={getOutgoingMessageState(channel, message) !== OutgoingMessageStates.PENDING}
+                    isClickable={getOutgoingMessageState(channel, message) === OutgoingMessageStates.SENT}
                   />
                   <TextMessageItemBody
                     isByMe={isByMe}

--- a/src/rogu/ui/MessageItemMenu/index.tsx
+++ b/src/rogu/ui/MessageItemMenu/index.tsx
@@ -13,7 +13,7 @@ import {
 import { LocalizationContext } from '../../../lib/LocalizationContext';
 
 import Icon, { IconTypes, IconColors } from '../Icon';
-import ContextMenu, {MenuItems, MenuItem} from '../ContextMenu';
+import ContextMenu, { MenuItems, MenuItem } from '../ContextMenu';
 import Toast from '../Toast';
 
 import "./index.scss";
@@ -53,17 +53,17 @@ export default function MessageItemMenu({
   const showMenuItemReply: boolean = isUserMessage(message as UserMessage);
   const showMenuItemResend: boolean = (isFailedMessage(channel, message) && message.isResendable() && isByMe);
   const showMenuItemDelete: boolean = (isSentMessage(channel, message) && isByMe);
-  {/* hide menu edit */}
-  const showMenuItemEdit: boolean =false && (isUserMessage(message as UserMessage) && isSentMessage(channel, message) && isByMe);
+  {/* hide menu edit */ }
+  const showMenuItemEdit: boolean = false && (isUserMessage(message as UserMessage) && isSentMessage(channel, message) && isByMe);
 
-  {/* show menu view on image or video */}
-  const showMenuItemView:boolean = isThumbnailMessage(message as FileMessage);
+  {/* show menu view on image or video */ }
+  const showMenuItemView: boolean = isThumbnailMessage(message as FileMessage);
 
   if (!(showMenuItemCopy || showMenuItemEdit || showMenuItemResend || showMenuItemDelete || showMenuItemView)) {
     return null;
   }
 
-  const onCopyClick = (message:string) => {
+  const onCopyClick = (message: string) => {
     copyToClipboard(message);
     setShowToast(true);
     setTimeout(() => {
@@ -85,10 +85,10 @@ export default function MessageItemMenu({
             height="16px"
             onClick={(): void => {
               toggleDropdown();
-              setSupposedHover(true);
+              if (setSupposedHover && typeof setSupposedHover === 'function') setSupposedHover(true);
             }}
             onBlur={(): void => {
-              setSupposedHover(false);
+              if (setSupposedHover && typeof setSupposedHover === 'function') setSupposedHover(false);
             }}
           >
             <Icon
@@ -103,7 +103,7 @@ export default function MessageItemMenu({
         menuItems={(close: () => void): ReactElement => {
           const closeDropdown = (): void => {
             close();
-            setSupposedHover(false);
+            if (setSupposedHover && typeof setSupposedHover === 'function') setSupposedHover(false);
           };
           return (
             <MenuItems
@@ -130,7 +130,7 @@ export default function MessageItemMenu({
                 <MenuItem
                   className="rogu-message-item-menu__list__menu-item"
                   onClick={() => {
-                    onCopyClick((message as UserMessage)?.message);                    
+                    onCopyClick((message as UserMessage)?.message);
                     closeDropdown();
                   }}
                   iconType={IconTypes.ROGU_COPY}
@@ -144,14 +144,14 @@ export default function MessageItemMenu({
                   onClick={() => {
                     showFileViewer(true);
                     closeDropdown();
-                    
+
                   }}
                   iconType={IconTypes.DOWNLOAD}
                 >
                   {stringSet.MESSAGE_MENU__VIEW}
                 </MenuItem>
               )}
-              
+
               {showMenuItemEdit && (
                 <MenuItem
                   className="rogu-message-item-menu__list__menu-item"

--- a/src/rogu/ui/ThumbnailMessageItemBody/index.tsx
+++ b/src/rogu/ui/ThumbnailMessageItemBody/index.tsx
@@ -23,7 +23,6 @@ export default function ThumbnailMessageItemBody({
   showFileViewer,
   isClickable = true,
 }: Props): ReactElement {
-  console.log('message', message);
   const { thumbnails = [] } = message;
   const thumbnailUrl: string = thumbnails.length > 0 ? thumbnails[0]?.url : '';
 

--- a/src/rogu/ui/ThumbnailMessageItemBody/index.tsx
+++ b/src/rogu/ui/ThumbnailMessageItemBody/index.tsx
@@ -12,6 +12,7 @@ interface Props {
   isByMe?: boolean;
   mouseHover?: boolean;
   showFileViewer?: (bool: boolean) => void;
+  isClickable: boolean,
 }
 
 export default function ThumbnailMessageItemBody({
@@ -20,6 +21,7 @@ export default function ThumbnailMessageItemBody({
   isByMe = false,
   mouseHover = false,
   showFileViewer,
+  isClickable = true,
 }: Props): ReactElement {
   console.log('message', message);
   const { thumbnails = [] } = message;
@@ -34,7 +36,7 @@ export default function ThumbnailMessageItemBody({
         mouseHover ? 'mouse-hover' : '',
         message?.reactions?.length > 0 ? 'reactions' : '',
       ])}
-      onClick={() => showFileViewer(true)}
+      onClick={isClickable ? () => showFileViewer(true) : () => { }}
     >
       <ImageRenderer
         className="rogu-thumbnail-message-item-body__thumbnail"

--- a/src/ui/FileViewer/index.jsx
+++ b/src/ui/FileViewer/index.jsx
@@ -27,7 +27,7 @@ export const FileViewerComponent = ({
     <div className="sendbird-fileviewer__header">
       <div className="sendbird-fileviewer__header__left">
         <div className="sendbird-fileviewer__header__left__avatar">
-          <Avatar height="32px" width="32px" src={profileUrl} />
+          {profileUrl && <Avatar height="32px" width="32px" src={profileUrl} />}
         </div>
         <Label
           className="sendbird-fileviewer__header__left__filename"

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -96,7 +96,7 @@ export interface OutgoingMessageStates {
   READ: "READ";
   // delivered and read are only in group channel
 }
-const OutgoingMessageStates: OutgoingMessageStates = {
+export const OutgoingMessageStates: OutgoingMessageStates = {
   NONE: "NONE",
   PENDING: "PENDING",
   SENT: "SENT",


### PR DESCRIPTION
> This project is a forked version of the [Sendbird UI Kit](https://github.com/sendbird/sendbird-uikit-react) to match with the Ruangguru's internal requirements. Therefore, it is not yet set up to accept pull requests from external contributors. But you can always freely create a forked version from this repository to match your own requirements.

## Related Issue
- Error in lms-web, bubble menu dropdown cause error
[slack thread](https://ruangguru.slack.com/archives/G013CQ8KZPF/p1635408941001500)
- FileViewer error when clicking thumbnail of a message that is still in sending state

## Description Of Changes
- [x] Check `setSupposedHover`
- [x] Disable thumbnail onClick when still sending

