### PR TITLE
refactor: use configured value from SUPPORTED_MIMES

### DIFF
--- a/src/rogu/ui/MessageInput/index.jsx
+++ b/src/rogu/ui/MessageInput/index.jsx
@@ -11,6 +11,7 @@ import { getClassName } from '../../../utils';
 import Icon, { IconTypes, IconColors } from '../Icon';
 import Label, { LabelTypography, LabelColors } from '../Label';
 import Toast from '../Toast';
+import { getMimeTypesString } from '../../utils';
 
 import './index.scss';
 
@@ -196,7 +197,7 @@ const MessageInput = React.forwardRef((props, ref) => {
                 height="20px"
               />
               <input
-                accept=".doc,.docx,.xls,.xlsx,.ppt,.pptx,.pdf,image/*,.mov,.mp4"
+                accept={getMimeTypesString()}
                 className="rogu-message-input--attach-input"
                 type="file"
                 ref={fileInputRef}

--- a/src/rogu/utils/fileType.ts
+++ b/src/rogu/utils/fileType.ts
@@ -103,3 +103,13 @@ export const getMimeExtension = (mimeType: string): string | undefined => {
     }
   }
 };
+
+export const getMimeTypesString = (): string => {
+  const mimeTypes = [];
+
+  for (const mimes of Object.values(SUPPORTED_MIMES)) {
+    mimes.forEach((mime) => mimeTypes.push(mime.mimeType));
+  }
+
+  return mimeTypes.join(',');
+};


### PR DESCRIPTION
> This project is a forked version of the [Sendbird UI Kit](https://github.com/sendbird/sendbird-uikit-react) to match with the Ruangguru's internal requirements. Therefore, it is not yet set up to accept pull requests from external contributors. But you can always freely create a forked version from this repository to match your own requirements.

## Related Issue

[RKLS-918](https://ruanggguru.atlassian.net/browse/RKLS-918)

## Description Of Changes

- Instead of using a hardcoded value in the `accept` attribute, I use the configured value from `SUPPORTED_MIMES` (`rogu/utils/fileType`)




<img width="684" alt="Screen Shot 2021-10-29 at 15 17 33" src="https://user-images.githubusercontent.com/24476578/139400574-e972ac04-a383-49b3-bd4b-f52b97bea7c4.png">

https://user-images.githubusercontent.com/24476578/139400048-c213df72-a41a-4896-a041-e1304c870f08.mp4



