### PR TITLE
fix: fix sticky positioning of DateSeparator

### DIFF
--- a/src/rogu/smart-components/Conversation/components/ConversationScroll.jsx
+++ b/src/rogu/smart-components/Conversation/components/ConversationScroll.jsx
@@ -130,7 +130,7 @@ export default class ConversationScroll extends Component {
 
                 return (
                   // eslint-disable-next-line react/no-array-index-key
-                  <React.Fragment key={i}>
+                  <div key={i}>
                     <DateSeparator createdAt={currentCreatedAt} />
                     {messages.map((m, idx) => {
                       const previousMessage = messages[idx - 1];
@@ -194,7 +194,7 @@ export default class ConversationScroll extends Component {
                         />
                       );
                     })}
-                  </React.Fragment>
+                  </div>
                 );
               },
             )}

--- a/src/rogu/ui/FileViewer/__tests__/__snapshots__/FileViewer.spec.js.snap
+++ b/src/rogu/ui/FileViewer/__tests__/__snapshots__/FileViewer.spec.js.snap
@@ -49,20 +49,16 @@ exports[`FileViewer should do a snapshot test of the FileViewer DOM 1`] = `
       <div
         className="rogu-fileviewer__header__left__metadata"
       >
-        <div>
-          <span
-            className="rogu-fileviewer__header__left__sender-name sendbird-label rogu-label--h-3 sendbird-label--color-onbackground-1"
-          >
-            namanya sangat panjang sampe sampe overflow
-          </span>
-        </div>
-        <div>
-          <span
-            className="rogu-fileviewer__header__left__createdat sendbird-label sendbird-label--body-1 sendbird-label--color-onbackground-2"
-          >
-            05/03/2020 20.43
-          </span>
-        </div>
+        <span
+          className="rogu-fileviewer__header__left__sender-name sendbird-label rogu-label--h-3 sendbird-label--color-onbackground-1"
+        >
+          namanya sangat panjang sampe sampe overflow
+        </span>
+        <span
+          className="rogu-fileviewer__header__left__createdat sendbird-label sendbird-label--body-1 sendbird-label--color-onbackground-2"
+        >
+          05/03/2020 20.43
+        </span>
       </div>
     </div>
     <div

--- a/src/rogu/ui/MessageInput/index.jsx
+++ b/src/rogu/ui/MessageInput/index.jsx
@@ -9,7 +9,6 @@ import { getClassName, isUrl } from '../../../utils';
 import IconButton from '../../../ui/IconButton';
 import Button, { ButtonTypes, ButtonSizes } from '../../../ui/Button';
 
-
 import { getMimeTypesString, isImage } from '../../utils';
 
 import OGMessageItemBody from '../OGMessageItemBody';
@@ -124,17 +123,19 @@ const MessageInput = React.forwardRef((props, ref) => {
           alt: 'test',
         },
       },
-      createdAt: 0, 
+      createdAt: 0,
     };
 
     if (loading) {
-      return <Label
-      className="rogu-message-input__text-loading"
-      type={LabelTypography.BODY_1}
-      color={LabelColors.ONBACKGROUND_1}
-    >
-      {stringSet.LABEL_LOADING}
-    </Label>;
+      return (
+        <Label
+          className="rogu-message-input__text-loading"
+          type={LabelTypography.BODY_1}
+          color={LabelColors.ONBACKGROUND_1}
+        >
+          {stringSet.LABEL_LOADING}
+        </Label>
+      );
     }
 
     return <OGMessageItemBody message={message} isOnPreview onClosePreview={() => setUrl({ hasUrl: false, text: '' })} />;
@@ -169,7 +170,7 @@ const MessageInput = React.forwardRef((props, ref) => {
       } else {
         onSendMessage(trimmedInputValue);
         setInputValue('');
-        if(elem){
+        if (elem) {
           elem.style.height = `${LINE_HEIGHT}px`;
         }
       }

--- a/src/rogu/ui/TextMessageItemBody/index.scss
+++ b/src/rogu/ui/TextMessageItemBody/index.scss
@@ -17,6 +17,7 @@
     border-left-width: 2px;
     border-left-style: solid;
     cursor: pointer;
+
     @include themed() {
       background-color: t(primary-2);
       border-left-color: t(primary-5);
@@ -52,6 +53,7 @@
         color: t(secondary-3);
       }
     }
+
     .rogu-text-message-item-body__reply-container {
       @include themed() {
         background-color: t(bg-1);

--- a/src/rogu/ui/TextMessageItemBody/index.tsx
+++ b/src/rogu/ui/TextMessageItemBody/index.tsx
@@ -45,8 +45,8 @@ export default function TextMessageItemBody({
   const [clampState, setClampState] = useState<ClampType>("init");
   const textRef = useRef<HTMLDivElement>(null);
 
-  let {sender, parentMessage, originalMessage} = isRepliedMessage && destructureRepliedMessage(message);
-  let msg = isRepliedMessage ? originalMessage : message;
+  const {sender, parentMessage, originalMessage} = isRepliedMessage && destructureRepliedMessage(message);
+  const msg = isRepliedMessage ? originalMessage : message;
   
 
   useEffect(() => {
@@ -60,9 +60,9 @@ export default function TextMessageItemBody({
 
   function handleExpand() {
     setClampState("expanded");
-  };
+  }
 
-  let renderRepliedMessage = (sender, parentMessage) => {
+  const renderRepliedMessage = (sender, parentMessage) => {
     return <div className="rogu-text-message-item-body__reply-container" onClick={onScrollToMessage} >
       <Label
         className="rogu-message-content__sender-name"

--- a/src/rogu/utils/message.ts
+++ b/src/rogu/utils/message.ts
@@ -28,15 +28,15 @@ type structureRepliedMessage = {
 
 const QUOTE_FORMAT = ">";
 
-let isQuoteFormat = (word:string):boolean => {
+const isQuoteFormat = (word:string):boolean => {
   return word.charAt(0) === QUOTE_FORMAT    
 };
 
 export const destructureRepliedMessage = (message:string):structureRepliedMessage => {
-  let repliedMessage = message.split("\n").filter(word => isQuoteFormat(word)).map(word => word.substr(1));
-  let [sender, ...rest] = repliedMessage;
-  let parentMessage = rest.join("\n");
-  let originalMessage = message.split("\n").filter(word => !isQuoteFormat(word)).join("\n");
+  const repliedMessage = message.split("\n").filter(word => isQuoteFormat(word)).map(word => word.substr(1));
+  const [sender, ...rest] = repliedMessage;
+  const parentMessage = rest.join("\n");
+  const originalMessage = message.split("\n").filter(word => !isQuoteFormat(word)).join("\n");
   return {
     sender: sender,
     parentMessage,


### PR DESCRIPTION
> This project is a forked version of the [Sendbird UI Kit](https://github.com/sendbird/sendbird-uikit-react) to match with the Ruangguru's internal requirements. Therefore, it is not yet set up to accept pull requests from external contributors. But you can always freely create a forked version from this repository to match your own requirements.

## Related Issue

- 

## Description Of Changes

To create a sticky behaviour of the date separator, we group messages by date and render those messages in each container while appending a `DateSeparator` with `position: sticky`.

In the current implementation, we use `React.Fragment` as a container, so it will not create any block-level ancestor. It makes the DateSeparators are sticky positioned relative to the chatroom container.

https://user-images.githubusercontent.com/24476578/140245125-c8dd76a6-0e5a-4721-b85e-f371b4c16644.mp4

To fix this issue, we just need to render a "real" element (i.e. `div`) as the container of grouped messages to create a block-level ancestor of the date separator. 


https://user-images.githubusercontent.com/24476578/140245272-e5dd5154-c4f9-403f-b610-e0dba37dd047.mp4



