### PR TITLE
fix: refine unread notification string and hover color

### DIFF
--- a/__mocks__/themeMock.js
+++ b/__mocks__/themeMock.js
@@ -6,4 +6,5 @@ export default {
   '--sendbird-light-background-700': '#BEC8D0',
   '--sendbird-light-onlight-01': '#434856',
   '--sendbird-light-secondary-300': '#2EB5C0',
+  '--sendbird-light-secondary-200': '#25919A',
 };

--- a/src/rogu/smart-components/Conversation/components/notification.scss
+++ b/src/rogu/smart-components/Conversation/components/notification.scss
@@ -1,4 +1,4 @@
-@import "../../../../styles/variables";
+@import '../../../../styles/variables';
 
 .rogu-notification {
   margin-top: 8px;
@@ -24,6 +24,10 @@
 
   &:hover {
     cursor: pointer;
+
+    @include themed() {
+      background-color: t(secondary-2);
+    }
   }
 
   &.rogu-notification--frozen {

--- a/src/rogu/smart-components/Conversation/dux/reducers.js
+++ b/src/rogu/smart-components/Conversation/dux/reducers.js
@@ -208,7 +208,7 @@ export default function reducer(state, action) {
         ...state,
         unreadCount,
         unreadSince: (unreadCount === 1)
-          ? format(new Date(), 'p MMM dd')
+          ? format(new Date(), 'HH.mm dd MMM yyyy')
           : unreadSince,
         allMessages: passUnsuccessfullMessages(state.allMessages, message),
       };

--- a/src/rogu/ui/FileViewer/index.jsx
+++ b/src/rogu/ui/FileViewer/index.jsx
@@ -83,6 +83,7 @@ export const FileViewerComponent = ({
                 rel="noopener noreferrer"
                 href={url}
                 onClick={onDownloadClick}
+                target="_blank"
               >
                 <Icon
                   type={IconTypes.ROGU_DOWNLOAD}


### PR DESCRIPTION
> This project is a forked version of the [Sendbird UI Kit](https://github.com/sendbird/sendbird-uikit-react) to match with the Ruangguru's internal requirements. Therefore, it is not yet set up to accept pull requests from external contributors. But you can always freely create a forked version from this repository to match your own requirements.

## Description Of Changes

Fix unread notification string and hover color

Before
![Screen Shot 2021-11-08 at 14 55 36](https://user-images.githubusercontent.com/26358930/140704163-be45dc41-3a05-4940-bb9e-1f9fca656f1e.png)

After
![Screen Shot 2021-11-08 at 14 55 48](https://user-images.githubusercontent.com/26358930/140704183-44e55f1a-58a7-4f1e-9a4c-f7f3761ae842.png)


