### PR TITLE
fix(component): hide EMPTY_MESSAGE caption appearing in web when media message sent from android

### DIFF
--- a/src/rogu/ui/MessageContent/index.tsx
+++ b/src/rogu/ui/MessageContent/index.tsx
@@ -230,7 +230,7 @@ export default function MessageContent({
                       OutgoingMessageStates.PENDING
                     }
                   />
-                  {(message as FileMessage).name && (
+                  {(message as FileMessage).name !== 'EMPTY_MESSAGE' && (
                     <ClampedMessageItemBody
                       isByMe={isByMe}
                       mode="thumbnailCaption"


### PR DESCRIPTION
> This project is a forked version of the [Sendbird UI Kit](https://github.com/sendbird/sendbird-uikit-react) to match with the Ruangguru's internal requirements. Therefore, it is not yet set up to accept pull requests from external contributors. But you can always freely create a forked version from this repository to match your own requirements.

## Related Issue

[RKLS-1088](https://ruanggguru.atlassian.net/browse/RKLS-1088)

## Description Of Changes

Fix EMPTY_MESSAGE appearing in web when media message sent from android

### Before
![Screen Shot 2021-11-09 at 14 11 36](https://user-images.githubusercontent.com/26358930/140882839-4e5803d3-8f55-4533-99ac-d8ea1c7282a0.png)


### After
![Screen Shot 2021-11-09 at 14 11 22](https://user-images.githubusercontent.com/26358930/140882854-03c1f0a7-94d8-4ec3-9701-43b036e303ef.png)

