### PR TITLE
fix: refine archive banner width

### DIFF
--- a/src/rogu/smart-components/Conversation/components/archived-banner.scss
+++ b/src/rogu/smart-components/Conversation/components/archived-banner.scss
@@ -1,7 +1,6 @@
 @import '../../../../styles/variables';
 
 .rogu-archived-banner {
-  width: 100%;
   margin: -12px -16px;
   padding: 0.75rem 1rem;
   display: flex;


### PR DESCRIPTION
> This project is a forked version of the [Sendbird UI Kit](https://github.com/sendbird/sendbird-uikit-react) to match with the Ruangguru's internal requirements. Therefore, it is not yet set up to accept pull requests from external contributors. But you can always freely create a forked version from this repository to match your own requirements.

## Related Issue

Archive banner not full width because container have padding (because of refactor of footer)

### Before
<img width="617" alt="Screen Shot 2021-11-09 at 17 26 21" src="https://user-images.githubusercontent.com/26358930/140907857-2dfe6feb-6571-477c-96d6-4a619ca2e44c.png">


### After
<img width="619" alt="Screen Shot 2021-11-09 at 17 26 38" src="https://user-images.githubusercontent.com/26358930/140907871-6c3442c7-408b-4f2f-8b52-9bb3f94cc974.png">


