### PR TITLE
feat: handle message reply that contains another replied message

### DIFF
--- a/src/rogu/smart-components/Conversation/index.jsx
+++ b/src/rogu/smart-components/Conversation/index.jsx
@@ -118,7 +118,7 @@ export const ConversationPanel = (props) => {
   const userDefinedRenderProfile = renderUserProfile || config.renderUserProfile;
   const showScrollBot = hasMoreToBottom;
 
-  // Replied message
+  // Reply message
   const [repliedMessage, setRepliedMessage] = useState();
 
   // TODO: emojiAllMap, emoijAllList, nicknamesMap => should be moved to messagesStore

--- a/src/rogu/ui/MessageInput/RepliedMessagePreview.tsx
+++ b/src/rogu/ui/MessageInput/RepliedMessagePreview.tsx
@@ -15,9 +15,15 @@ import { FileMessage, UserMessage } from 'sendbird';
 import RepliedTextMessageItemBody from '../RepliedTextMessageItemBody';
 
 import { isOGMessage, isTextMessage } from '../../../utils';
+import {
+  destructureRepliedMessage,
+  isFileMessage,
+  isReplyingMessage,
+} from '../../utils';
 
 export type RepliedMessagePreviewProps = {
   className?: string;
+  isByMe: boolean;
   message: FileMessage | UserMessage;
   onClick?: (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => void;
   onCancel?: (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => void;
@@ -29,14 +35,26 @@ export function RepliedMessagePreview({
   onCancel,
   onClick,
 }: RepliedMessagePreviewProps): JSX.Element {
+  const nickname = message.sender?.nickname;
+  let body = isFileMessage(message as FileMessage)
+    ? (message as FileMessage).name
+    : (message as UserMessage).message;
+
+  // if the replied message is replying another message
+  if (isReplyingMessage(message)) {
+    const { originalMessage } = destructureRepliedMessage(body);
+
+    body = originalMessage;
+  }
+
   return (
     <div className={className}>
       {(isTextMessage(message as UserMessage) ||
         isOGMessage(message as UserMessage)) && (
         <RepliedTextMessageItemBody
-          content={(message as UserMessage).message}
-          isByMe={false}
-          nickname={message.sender?.nickname}
+          content={body}
+          isByMe={false} // always false to match the styling
+          nickname={nickname}
           withCancelButton
           onClick={onClick}
           onCancel={onCancel}


### PR DESCRIPTION
> This project is a forked version of the [Sendbird UI Kit](https://github.com/sendbird/sendbird-uikit-react) to match with the Ruangguru's internal requirements. Therefore, it is not yet set up to accept pull requests from external contributors. But you can always freely create a forked version from this repository to match your own requirements.

## Related Issue

[RKLS-1105](https://ruanggguru.atlassian.net/browse/RKLS-1105)

## Description Of Changes

In this PR, I added a functionality to reply to a message that contains another replied message.

### Technical Approach
- `RepliedMessagePreview` and `MessageInput`: destructure replied message. Only pass the original message if the replied message contains another replied message.

### Demo

https://user-images.githubusercontent.com/24476578/141046231-2b1e375b-206e-46df-b556-3ebc4c634cf4.mp4


<img src="https://user-images.githubusercontent.com/24476578/141046347-4d0fecdf-286a-48ac-bb4f-1e45ed659fb5.jpg" width="240" />

