### PR TITLE
feat: add feature to reply to a file message

### DIFF
--- a/src/rogu/smart-components/Conversation/hooks/useSendFileMessageCallback.js
+++ b/src/rogu/smart-components/Conversation/hooks/useSendFileMessageCallback.js
@@ -30,7 +30,7 @@ export default function useSendFileMessageCallback(
       const compressibleDiamensions = utils.pxToNumber(resizingWidth)
         || utils.pxToNumber(resizingHeight);
 
-      const canCompressImage = compressibleFileType 
+      const canCompressImage = compressibleFileType
         && (compressibleRatio || compressibleDiamensions);
 
       const createParamsDefault = (file_) => {

--- a/src/rogu/smart-components/Conversation/hooks/useSendFileMessageCallback.js
+++ b/src/rogu/smart-components/Conversation/hooks/useSendFileMessageCallback.js
@@ -82,19 +82,9 @@ export default function useSendFileMessageCallback(
 
                 // Add meta arrays param for replied message
                 if (repliedMessage) {
-                  const {
-                    parentMessageBody,
-                    parentMessageId,
-                    parentMessageNickname,
-                  } = repliedMessage;
-
                   params.metaArrays = [
                     ...params.metaArrays,
-                    ...repliedMessageToMetaArrays(sdk, {
-                      parentMessageBody,
-                      parentMessageId,
-                      parentMessageNickname,
-                    }),
+                    ...repliedMessageToMetaArrays(sdk, repliedMessage),
                   ];
                 }
 
@@ -165,19 +155,9 @@ export default function useSendFileMessageCallback(
 
         // Add meta arrays param for replied message
         if (repliedMessage) {
-          const {
-            parentMessageBody,
-            parentMessageId,
-            parentMessageNickname,
-          } = repliedMessage;
-
           params.metaArrays = [
             ...params.metaArrays,
-            ...repliedMessageToMetaArrays(sdk, {
-              parentMessageBody,
-              parentMessageId,
-              parentMessageNickname,
-            }),
+            ...repliedMessageToMetaArrays(sdk, repliedMessage),
           ];
         }
 

--- a/src/rogu/smart-components/Conversation/hooks/useSendFileMessageCallback.js
+++ b/src/rogu/smart-components/Conversation/hooks/useSendFileMessageCallback.js
@@ -30,7 +30,7 @@ export default function useSendFileMessageCallback(
       const compressibleDiamensions = utils.pxToNumber(resizingWidth)
         || utils.pxToNumber(resizingHeight);
 
-      const canCompressImage = compressibleFileType
+      const canCompressImage = compressibleFileType 
         && (compressibleRatio || compressibleDiamensions);
 
       const createParamsDefault = (file_) => {
@@ -82,19 +82,9 @@ export default function useSendFileMessageCallback(
 
                 // Add meta arrays param for replied message
                 if (repliedMessage) {
-                  const {
-                    parentMessageBody,
-                    parentMessageId,
-                    parentMessageNickname,
-                  } = repliedMessage;
-
                   params.metaArrays = [
                     ...params.metaArrays,
-                    ...repliedMessageToMetaArrays(sdk, {
-                      parentMessageBody,
-                      parentMessageId,
-                      parentMessageNickname,
-                    }),
+                    ...repliedMessageToMetaArrays(sdk, repliedMessage),
                   ];
                 }
 
@@ -165,19 +155,9 @@ export default function useSendFileMessageCallback(
 
         // Add meta arrays param for replied message
         if (repliedMessage) {
-          const {
-            parentMessageBody,
-            parentMessageId,
-            parentMessageNickname,
-          } = repliedMessage;
-
           params.metaArrays = [
             ...params.metaArrays,
-            ...repliedMessageToMetaArrays(sdk, {
-              parentMessageBody,
-              parentMessageId,
-              parentMessageNickname,
-            }),
+            ...repliedMessageToMetaArrays(sdk, repliedMessage),
           ];
         }
 

--- a/src/rogu/smart-components/Conversation/hooks/useSendMessageCallback.js
+++ b/src/rogu/smart-components/Conversation/hooks/useSendMessageCallback.js
@@ -3,7 +3,10 @@ import { useRef, useCallback } from 'react';
 import * as messageActionTypes from '../dux/actionTypes';
 import * as utils from '../utils';
 import * as topics from '../../../../lib/pubSub/topics';
-import { repliedMessageToFormatedString } from '../../../utils';
+import {
+  repliedMessageToFormatedString,
+  repliedMessageToMetaArrays,
+} from '../../../utils';
 
 export default function useSendMessageCallback(
   { currentGroupChannel, onBeforeSendUserMessage },
@@ -39,23 +42,15 @@ export default function useSendMessageCallback(
         : createParamsDefault(text);
 
       if (repliedMessage) {
-        const {
-          parentMessageBody,
-          parentMessageId,
-          parentMessageNickname,
-        } = repliedMessage;
-
         params.metaArrays = [
           ...params.metaArrays,
-          new sdk.MessageMetaArray('parentMessageId', [
-            String(parentMessageId),
-          ]),
+          ...repliedMessageToMetaArrays(sdk, repliedMessage),
         ];
 
         params.message = repliedMessageToFormatedString({
           originalMessage: text,
-          parentMessageBody,
-          parentMessageNickname,
+          parentMessageBody: repliedMessage.parentMessageBody,
+          parentMessageNickname: repliedMessage.parentMessageNickname,
         });
       }
 

--- a/src/rogu/ui/FileMessageItemBody/index.scss
+++ b/src/rogu/ui/FileMessageItemBody/index.scss
@@ -2,7 +2,6 @@
 
 .rogu-file-message-item-body {
   display: flex;
-  align-items: center;
   border-radius: 0.25rem;
   padding: 0.5rem;
   min-width: 200px;

--- a/src/rogu/ui/MessageInput/RepliedMessagePreview.tsx
+++ b/src/rogu/ui/MessageInput/RepliedMessagePreview.tsx
@@ -1,7 +1,7 @@
 /**
  * TODO
  * [x] Handle reply text message
- * [ ] Handle reply file message
+ * [x] Handle reply file message
  * [ ] Handle reply assignment message
  * [ ] Handle reply material message
  * [ ] Handle reply image message
@@ -13,8 +13,14 @@ import React from 'react';
 import { FileMessage, UserMessage } from 'sendbird';
 
 import RepliedTextMessageItemBody from '../RepliedTextMessageItemBody';
+import RepliedFileMessageItemBody from '../RepliedFileMessageItemBody';
 
-import { isOGMessage, isTextMessage } from '../../../utils';
+import {
+  getUIKitMessageType,
+  getUIKitMessageTypes,
+  isOGMessage,
+  isTextMessage,
+} from '../../../utils';
 import {
   formatedStringToRepliedMessage,
   isFileMessage,
@@ -35,10 +41,16 @@ export function RepliedMessagePreview({
   onCancel,
   onClick,
 }: RepliedMessagePreviewProps): JSX.Element {
+  const messageTypes = getUIKitMessageTypes();
+
   const nickname = message.sender?.nickname;
-  let body = isFileMessage(message as FileMessage)
-    ? (message as FileMessage).name
-    : (message as UserMessage).message;
+  let body = (message as UserMessage).message;
+  let mimeType = "*";
+
+  if (isFileMessage(message as FileMessage)) {
+    body = (message as FileMessage).name;
+    mimeType = (message as FileMessage).type;
+  }
 
   // if the replied message is replying another message
   if (isReplyingMessage(message)) {
@@ -54,6 +66,18 @@ export function RepliedMessagePreview({
         <RepliedTextMessageItemBody
           content={body}
           isByMe={false} // always false to match the styling
+          nickname={nickname}
+          withCancelButton
+          onClick={onClick}
+          onCancel={onCancel}
+        />
+      )}
+
+      {getUIKitMessageType(message as FileMessage) === messageTypes.FILE && (
+        <RepliedFileMessageItemBody
+          body={body}
+          isByMe={false} // always false to match the styling
+          mimeType={mimeType}
           nickname={nickname}
           withCancelButton
           onClick={onClick}

--- a/src/rogu/ui/MessageInput/index.jsx
+++ b/src/rogu/ui/MessageInput/index.jsx
@@ -22,6 +22,7 @@ import {
   isImage,
   isReplyingMessage,
   SUPPORTED_MIMES,
+  REPLIED_MESSAGE_TYPE,
 } from '../../utils';
 import { getUrlFromWords, debounce } from './utils';
 
@@ -172,9 +173,15 @@ const MessageInput = React.forwardRef((props, ref) => {
       modifiedFile.name = inputValue;
 
       if (repliedMessage) {
-        let repliedMessageBody = isFileMessage(repliedMessage)
-          ? repliedMessage.name
-          : repliedMessage.message;
+        let repliedMessageBody = repliedMessage.message;
+        let repliedMessageMimeType = '*';
+        let repliedMessageType = REPLIED_MESSAGE_TYPE.Text;
+
+        if (isFileMessage(repliedMessage)) {
+          repliedMessageBody = repliedMessage.name;
+          repliedMessageMimeType = repliedMessage.type;
+          repliedMessageType = REPLIED_MESSAGE_TYPE.File;
+        }
 
         // if the replied message is replying another message
         if (isReplyingMessage(repliedMessage)) {
@@ -187,16 +194,24 @@ const MessageInput = React.forwardRef((props, ref) => {
         onFileUpload(modifiedFile, {
           parentMessageBody: repliedMessageBody,
           parentMessageId: repliedMessage.messageId,
+          parentMessageMimeType: repliedMessageMimeType,
           parentMessageNickname: repliedMessage.sender?.nickname,
+          parentMessageType: repliedMessageType,
         });
       } else {
         onFileUpload(modifiedFile);
       }
     } else if (inputValue && inputValue.trim().length > 0) {
       if (repliedMessage) {
-        let repliedMessageBody = isFileMessage(repliedMessage)
-          ? repliedMessage.name
-          : repliedMessage.message;
+        let repliedMessageBody = repliedMessage.message;
+        let repliedMessageMimeType = '*';
+        let repliedMessageType = REPLIED_MESSAGE_TYPE.Text;
+
+        if (isFileMessage(repliedMessage)) {
+          repliedMessageBody = repliedMessage.name;
+          repliedMessageMimeType = repliedMessage.type;
+          repliedMessageType = REPLIED_MESSAGE_TYPE.File;
+        }
 
         // if the replied message is replying another message
         if (isReplyingMessage(repliedMessage)) {
@@ -210,7 +225,9 @@ const MessageInput = React.forwardRef((props, ref) => {
         onSendMessage({
           parentMessageBody: repliedMessageBody,
           parentMessageId: repliedMessage.messageId,
+          parentMessageMimeType: repliedMessageMimeType,
           parentMessageNickname: repliedMessage.sender?.nickname,
+          parentMessageType: repliedMessageType,
         });
       } else {
         onSendMessage();

--- a/src/rogu/ui/RepliedFileMessageItemBody/index.scss
+++ b/src/rogu/ui/RepliedFileMessageItemBody/index.scss
@@ -1,0 +1,63 @@
+@import '../../../styles/variables';
+
+.rogu-replied-file-message-item-body {
+  padding: 8px;
+  border-radius: 4px;
+  margin-bottom: 8px;
+  border-left-width: 2px;
+  border-left-style: solid;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+
+  @include themed() {
+    border-left-color: t(primary-5);
+  }
+
+  &.rogu-replied-file-message-item-body--outgoing {
+    @include themed() {
+      background-color: t(primary-2);
+    }
+  }
+
+  &.rogu-replied-file-message-item-body--incoming {
+    @include themed() {
+      background-color: t(bg-1);
+    }
+  }
+
+  .rogu-replied-file-message-item-body__content {
+    display: flex;
+
+    .rogu-replied-file-message-item-body__icon {
+      width: 28px;
+      height: 28px;
+      border-radius: 8px;
+      margin-right: 8px;
+    }
+
+    .rogu-replied-file-message-item-body__content__nickname,
+    .rogu-replied-file-message-item-body__content__message {
+      white-space: pre-wrap;
+      word-break: break-word;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      display: -webkit-box;
+      -webkit-box-orient: vertical;
+    }
+
+    .rogu-replied-file-message-item-body__content__nickname {
+      -webkit-line-clamp: 1;
+    }
+
+    .rogu-replied-file-message-item-body__content__message {
+      -webkit-line-clamp: 2;
+    }
+  }
+
+  .rogu-replied-file-message-item-body__cancel {
+    flex-shrink: 0;
+    margin: 0 20px;
+  }
+}

--- a/src/rogu/ui/RepliedFileMessageItemBody/index.tsx
+++ b/src/rogu/ui/RepliedFileMessageItemBody/index.tsx
@@ -1,0 +1,104 @@
+import React from 'react';
+
+import Label, { LabelTypography, LabelColors } from '../Label';
+import Icon, { IconTypes, IconColors } from '../Icon';
+import IconButton from '../IconButton';
+
+import generateColorFromString from '../MessageContent/utils';
+import { getClassName } from '../../../utils';
+import { getFileType } from '../../utils';
+
+import './index.scss';
+
+export type RepliedFileMessageItemBodyProps = {
+  body: string;
+  isByMe: boolean;
+  mimeType: string;
+  nickname: string;
+  withCancelButton?: boolean;
+  onCancel?: (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => void;
+  onClick?: (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => void;
+};
+
+export default function RepliedTextMessageItemBody({
+  body,
+  isByMe,
+  mimeType,
+  nickname,
+  withCancelButton = false,
+  onCancel,
+  onClick,
+}: RepliedFileMessageItemBodyProps): JSX.Element {
+  return (
+    <div
+      className={getClassName([
+        'rogu-replied-file-message-item-body',
+        isByMe
+          ? 'rogu-replied-file-message-item-body--outgoing'
+          : 'rogu-replied-file-message-item-body--incoming',
+      ])}
+      role="button"
+      tabIndex={0}
+      onClick={(e) => {
+        if (onClick) onClick(e);
+      }}
+    >
+      <div className="rogu-replied-file-message-item-body__content">
+        <Icon
+          className={'rogu-replied-file-message-item-body__icon'}
+          type={
+            {
+              WORD: IconTypes.ROGU_FILE_WORD,
+              EXCEL: IconTypes.ROGU_FILE_EXCEL,
+              POWERPOINT: IconTypes.ROGU_FILE_POWERPOINT,
+              PDF: IconTypes.ROGU_FILE_PDF,
+              OTHERS: IconTypes.ROGU_FILE_OTHERS,
+            }[getFileType(mimeType)]
+          }
+          fillColor={IconColors.PRIMARY}
+          width="28px"
+          height="28px"
+        />
+        <div>
+          <Label
+            className="rogu-replied-file-message-item-body__content__nickname"
+            color={LabelColors.ONBACKGROUND_2}
+            style={{
+              color: generateColorFromString(nickname || ''),
+            }}
+            type={LabelTypography.CAPTION_1}
+          >
+            {nickname}
+          </Label>
+          <Label
+            className="rogu-replied-file-message-item-body__content__message"
+            color={LabelColors.ONBACKGROUND_1}
+            type={LabelTypography.BODY_3}
+          >
+            {body}
+          </Label>
+        </div>
+      </div>
+
+      {withCancelButton && (
+        <IconButton
+          className="rogu-replied-file-message-item-body__cancel"
+          width="24px"
+          height="24px"
+          onClick={(e) => {
+            if (onCancel && typeof onCancel === 'function') {
+              onCancel(e);
+            }
+          }}
+        >
+          <Icon
+            type={IconTypes.CLOSE}
+            fillColor={IconColors.ON_BACKGROUND_1}
+            width="24px"
+            height="24px"
+          />
+        </IconButton>
+      )}
+    </div>
+  );
+}

--- a/src/rogu/ui/RepliedFileMessageItemBody/stories/RepliedFileMessageItemBody.stories.js
+++ b/src/rogu/ui/RepliedFileMessageItemBody/stories/RepliedFileMessageItemBody.stories.js
@@ -1,0 +1,43 @@
+import React from 'react';
+
+import RepliedFileMessageItemBody from '../index.tsx';
+import SendbirdProvider from '../../../../lib/Sendbird';
+
+import COLOR_SET from '../../../../../__mocks__/themeMock';
+import { STRING_SET } from '../../../../../__mocks__/localizationMock';
+
+export default { title: 'ruangkelas/UI Components/RepliedFileMessageItemBody' };
+
+export const outgoing = () => (
+  <SendbirdProvider
+    appId="dummy"
+    userID="dummy"
+    colorSet={COLOR_SET}
+    stringSet={STRING_SET}
+  >
+    <RepliedFileMessageItemBody
+      body="File Penting.pdf"
+      isByMe={true}
+      mimeType="application/pdf"
+      nickname="Kukuh Sulistyo"
+      onClick={() => console.log('Scroll to the message')}
+    />
+  </SendbirdProvider>
+);
+
+export const incoming = () => (
+  <SendbirdProvider
+    appId="dummy"
+    userID="dummy"
+    colorSet={COLOR_SET}
+    stringSet={STRING_SET}
+  >
+    <RepliedFileMessageItemBody
+      body="File Penting.pdf"
+      isByMe={false}
+      mimeType="application/pdf"
+      nickname="Kukuh Sulistyo"
+      onClick={() => console.log('Scroll to the message')}
+    />
+  </SendbirdProvider>
+);

--- a/src/rogu/ui/RepliedMessageItemBody/index.tsx
+++ b/src/rogu/ui/RepliedMessageItemBody/index.tsx
@@ -1,7 +1,7 @@
 /**
  * TODO
  * [x] Handle normal text message
- * [ ] Handle file message
+ * [x] Handle file message
  * [ ] Handle assignment message
  * [ ] Handle material message
  * [ ] Handle image message
@@ -10,33 +10,44 @@
 import React from 'react';
 
 import RepliedTextMessageItemBody from '../RepliedTextMessageItemBody';
+import RepliedFileMessageItemBody from '../RepliedFileMessageItemBody';
 
-export enum RepliedMessageTypes {
-  Text,
-}
+import { RepliedMessageType } from '../../utils';
 
 export type RepliedMessageItemBodyProps = {
-  type: RepliedMessageTypes;
+  type: RepliedMessageType;
+  body: string;
+  mimeType?: string;
   nickname: string;
-  messageContent: string;
   isByMe: boolean;
-  onClick;
+  onClick?: (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => void;
 };
 export function RepliedMessageItemBody({
+  body,
   isByMe,
+  mimeType,
   nickname,
-  messageContent,
   type,
   onClick,
 }: RepliedMessageItemBodyProps): JSX.Element {
   switch (type) {
-    case RepliedMessageTypes.Text:
+    case RepliedMessageType.Text:
       return (
         <RepliedTextMessageItemBody
           isByMe={isByMe}
           nickname={nickname}
-          content={messageContent}
+          content={body}
           onClick={onClick}
+        />
+      );
+    case RepliedMessageType.File:
+      return (
+        <RepliedFileMessageItemBody
+          body={body}
+          isByMe={isByMe}
+          mimeType={mimeType}
+          nickname={nickname}
+          onClick={() => console.log('Scroll to the message')}
         />
       );
     default:

--- a/src/rogu/ui/TextMessageItemBody/index.tsx
+++ b/src/rogu/ui/TextMessageItemBody/index.tsx
@@ -2,10 +2,13 @@ import React, { ReactElement } from 'react';
 import { UserMessage } from 'sendbird';
 
 import ClampedTextMessageItemBody from '../ClampedMessageItemBody';
-import RepliedMessageItemBody, {
-  RepliedMessageTypes,
-} from '../RepliedMessageItemBody';
-import { formatedStringToRepliedMessage, isReplyingMessage } from '../../utils';
+import RepliedMessageItemBody from '../RepliedMessageItemBody';
+import {
+  formatedStringToRepliedMessage,
+  isReplyingMessage,
+  metaArraysToRepliedMessage,
+  RepliedMessageType,
+} from '../../utils';
 
 interface Props {
   className?: string | Array<string>;
@@ -22,25 +25,39 @@ export default function TextMessageItemBody({
   message,
   onClickRepliedMessage,
 }: Props): ReactElement {
-  const messageContent = message.message;
+  let repliedMessageNickname = '';
+  let repliedMessageBody = '';
+  let repliedMessageMimeType = '*';
+  let repliedMessageType = RepliedMessageType.Text;
+  let messageBody = message.message;
 
   const hasRepliedMessage = isReplyingMessage(message);
 
-  const { originalMessage, parentMessageBody, parentMessageNickname } =
-    hasRepliedMessage && formatedStringToRepliedMessage(messageContent);
-    
-  const resolvedMessageContent = hasRepliedMessage
-    ? originalMessage
-    : messageContent;
+  if (hasRepliedMessage) {
+    const {
+      originalMessage,
+      parentMessageBody,
+      parentMessageNickname,
+    } = formatedStringToRepliedMessage(messageBody);
+
+    const repliedMessage = metaArraysToRepliedMessage(message.metaArrays);
+
+    repliedMessageNickname = parentMessageNickname;
+    repliedMessageBody = parentMessageBody;
+    repliedMessageMimeType = repliedMessage.parentMessageMimeType;
+    repliedMessageType = repliedMessage.parentMessageType;
+    messageBody = originalMessage;
+  }
 
   return (
     <>
       {hasRepliedMessage && (
         <RepliedMessageItemBody
+          body={repliedMessageBody}
           isByMe={isByMe}
-          nickname={parentMessageNickname}
-          messageContent={parentMessageBody}
-          type={RepliedMessageTypes.Text}
+          mimeType={repliedMessageMimeType}
+          nickname={repliedMessageNickname}
+          type={repliedMessageType}
           onClick={onClickRepliedMessage}
         />
       )}
@@ -48,7 +65,7 @@ export default function TextMessageItemBody({
       <ClampedTextMessageItemBody
         className={className}
         isByMe={isByMe}
-        content={resolvedMessageContent}
+        content={messageBody}
       />
     </>
   );

--- a/src/rogu/ui/TextMessageItemBody/index.tsx
+++ b/src/rogu/ui/TextMessageItemBody/index.tsx
@@ -2,10 +2,13 @@ import React, { ReactElement } from 'react';
 import { UserMessage } from 'sendbird';
 
 import ClampedTextMessageItemBody from '../ClampedMessageItemBody';
-import RepliedMessageItemBody, {
-  RepliedMessageTypes,
-} from '../RepliedMessageItemBody';
-import { formatedStringToRepliedMessage, isReplyingMessage } from '../../utils';
+import RepliedMessageItemBody from '../RepliedMessageItemBody';
+import {
+  formatedStringToRepliedMessage,
+  isReplyingMessage,
+  metaArraysToRepliedMessage,
+  RepliedMessageType,
+} from '../../utils';
 
 interface Props {
   className?: string | Array<string>;
@@ -22,25 +25,40 @@ export default function TextMessageItemBody({
   message,
   onClickRepliedMessage,
 }: Props): ReactElement {
-  const messageContent = message.message;
+  let repliedMessageNickname = '';
+  let repliedMessageBody = '';
+  let repliedMessageMimeType = '*';
+  let repliedMessageType = RepliedMessageType.Text;
+  let messageBody = message.message;
 
   const hasRepliedMessage = isReplyingMessage(message);
+  console.log(hasRepliedMessage);
 
-  const { originalMessage, parentMessageBody, parentMessageNickname } =
-    hasRepliedMessage && formatedStringToRepliedMessage(messageContent);
-    
-  const resolvedMessageContent = hasRepliedMessage
-    ? originalMessage
-    : messageContent;
+  if (hasRepliedMessage) {
+    const {
+      originalMessage,
+      parentMessageBody,
+      parentMessageNickname,
+    } = formatedStringToRepliedMessage(messageBody);
+
+    const repliedMessage = metaArraysToRepliedMessage(message.metaArrays);
+
+    repliedMessageNickname = parentMessageNickname;
+    repliedMessageBody = parentMessageBody;
+    repliedMessageMimeType = repliedMessage.parentMessageMimeType;
+    repliedMessageType = repliedMessage.parentMessageType;
+    messageBody = originalMessage;
+  }
 
   return (
     <>
       {hasRepliedMessage && (
         <RepliedMessageItemBody
+          body={repliedMessageBody}
           isByMe={isByMe}
-          nickname={parentMessageNickname}
-          messageContent={parentMessageBody}
-          type={RepliedMessageTypes.Text}
+          mimeType={repliedMessageMimeType}
+          nickname={repliedMessageNickname}
+          type={repliedMessageType}
           onClick={onClickRepliedMessage}
         />
       )}
@@ -48,7 +66,7 @@ export default function TextMessageItemBody({
       <ClampedTextMessageItemBody
         className={className}
         isByMe={isByMe}
-        content={resolvedMessageContent}
+        content={messageBody}
       />
     </>
   );

--- a/src/rogu/ui/ThumbnailMessageItemBody/index.tsx
+++ b/src/rogu/ui/ThumbnailMessageItemBody/index.tsx
@@ -4,14 +4,9 @@ import './index.scss';
 
 import Icon, { IconTypes, IconColors } from '../Icon';
 import ImageRenderer from '../ImageRenderer';
-import RepliedMessageItemBody, {
-  RepliedMessageTypes,
-} from '../RepliedMessageItemBody';
+import RepliedMessageItemBody from '../RepliedMessageItemBody';
 import ClampedMessageItemBody from '../ClampedMessageItemBody';
-import {
-  metaArraysToRepliedMessage,
-  isReplyingMessage,
-} from '../../utils';
+import { isReplyingMessage, metaArraysToRepliedMessage } from '../../utils';
 import { getClassName, isGifMessage, isVideoMessage } from '../../../utils';
 
 interface Props {
@@ -41,15 +36,20 @@ export default function ThumbnailMessageItemBody({
   const hasRepliedMessage = isReplyingMessage(message);
 
   const renderRepliedMessage = () => {
-    const { parentMessageBody, parentMessageNickname } = metaArraysToRepliedMessage(
-      message.metaArrays
-    );
+    const {
+      parentMessageBody,
+      parentMessageMimeType,
+      parentMessageNickname,
+      parentMessageType,
+    } = metaArraysToRepliedMessage(message.metaArrays);
+
     return (
       <RepliedMessageItemBody
+        body={parentMessageBody}
         isByMe={isByMe}
+        mimeType={parentMessageMimeType}
         nickname={parentMessageNickname}
-        messageContent={parentMessageBody}
-        type={RepliedMessageTypes.Text}
+        type={parentMessageType}
         onClick={onClickRepliedMessage}
       />
     );

--- a/src/rogu/utils/repliedMessage.ts
+++ b/src/rogu/utils/repliedMessage.ts
@@ -6,11 +6,24 @@ import {
   REPLIED_MESSAGE_QUOTE_FORMAT,
 } from './constants';
 
+export enum RepliedMessageType {
+  Text = 'text',
+  File = 'file',
+}
+
+// For JS usage
+export const REPLIED_MESSAGE_TYPE = {
+  Text: 'text',
+  File: 'file',
+};
+
 export type RepliedMessage = {
   originalMessage?: string;
   parentMessageId: string;
   parentMessageBody: string;
+  parentMessageMimeType?: string;
   parentMessageNickname: string;
+  parentMessageType: RepliedMessageType;
 };
 
 export const formatedStringToRepliedMessage = (
@@ -32,6 +45,7 @@ export const formatedStringToRepliedMessage = (
     parentMessageId: '',
     parentMessageBody,
     parentMessageNickname,
+    parentMessageType: RepliedMessageType.Text,
   };
 };
 
@@ -98,5 +112,7 @@ export const metaArraysToRepliedMessage = (
       parentMessageId: '',
       parentMessageBody: '',
       parentMessageNickname: '',
+      parentMessageType: RepliedMessageType.Text,
+      parentMessageMimeType: '*',
     }
   );

--- a/src/rogu/utils/repliedMessage.ts
+++ b/src/rogu/utils/repliedMessage.ts
@@ -6,11 +6,24 @@ import {
   REPLIED_MESSAGE_QUOTE_FORMAT,
 } from './constants';
 
+export enum RepliedMessageType {
+  Text = 'text',
+  File = 'file',
+}
+
+// For JS usage
+export const REPLIED_MESSAGE_TYPE = {
+  Text: 'text',
+  File: 'file',
+};
+
 export type RepliedMessage = {
   originalMessage?: string;
   parentMessageId: string;
   parentMessageBody: string;
+  parentMessageMimeType?: string;
   parentMessageNickname: string;
+  parentMessageType: RepliedMessageType;
 };
 
 export const formatedStringToRepliedMessage = (
@@ -32,6 +45,7 @@ export const formatedStringToRepliedMessage = (
     parentMessageId: '',
     parentMessageBody,
     parentMessageNickname,
+    parentMessageType: RepliedMessageType.Text,
   };
 };
 
@@ -78,7 +92,7 @@ export const repliedMessageToMetaArrays = (
 
   Object.entries(repliedMessage).forEach(([key, value]) => {
     metaArrays.push(
-      new sdk.MessageMetaArray(key, stringToMetaArrayValue(value))
+      new sdk.MessageMetaArray(key, stringToMetaArrayValue(String(value)))
     );
   });
 
@@ -98,5 +112,7 @@ export const metaArraysToRepliedMessage = (
       parentMessageId: '',
       parentMessageBody: '',
       parentMessageNickname: '',
+      parentMessageType: RepliedMessageType.Text,
+      parentMessageMimeType: '*',
     }
   );


### PR DESCRIPTION
> This project is a forked version of the [Sendbird UI Kit](https://github.com/sendbird/sendbird-uikit-react) to match with the Ruangguru's internal requirements. Therefore, it is not yet set up to accept pull requests from external contributors. But you can always freely create a forked version from this repository to match your own requirements.

## Related Issue

[RKLS-1018](https://ruanggguru.atlassian.net/browse/RKLS-1018)

## Description Of Changes

In this PR, I added a feature to reply to a file message with text and an image. 

### Technical Approach
- Currently, Sendbird does not natively support a replied message as required. We use a workaround by storing each replied message data (i.e. `parentMessageType` and `parentMessageMimeType`) to the `sorted_metaarrays`
- Add `RepliedFileMessageItemBody` and use it in `RepliedMessageItemBody` and `RepliedMessagePreview`
- Note: This workaround is not yet implemented in the mobile app. So message reply to a file message that is sent from a mobile app will be shown as a reply to a text message in web app:
 

<img src="https://user-images.githubusercontent.com/24476578/141252710-b2f13bdb-3397-4472-92af-7b69ca8e1a8b.png" width="420" />

### Additional Changes
- Align file icon to the top

### Demo


https://user-images.githubusercontent.com/24476578/141246483-0b8fc2f5-5614-4112-8477-49e0e8906d55.mp4

<img src="https://user-images.githubusercontent.com/24476578/141252636-cbf3e712-3dd9-4a3a-b22b-e0146ba3d9f9.jpg" width="240" />


