### PR TITLE
feat: handle scrolling to replied message

### DIFF
--- a/src/rogu/smart-components/Conversation/components/ConversationScroll.jsx
+++ b/src/rogu/smart-components/Conversation/components/ConversationScroll.jsx
@@ -116,7 +116,6 @@ export default class ConversationScroll extends Component {
           className="rogu-conversation__scroll-container"
           onScroll={this.onScroll}
         >
-          <div className="rogu-conversation__padding" />
           {/*
             To do: Implement windowing
             Implement windowing if you are dealing with large number of messages/channels
@@ -124,147 +123,81 @@ export default class ConversationScroll extends Component {
             We hesitate to bring one more dependency to our library,
             we are planning to implement it inside the library
           */}
-          <div className="rogu-conversation__messages-padding">
-            {Array.from(groupMessagesByDate(allMessages).values()).map(
-              (messages, i) => {
-                const currentCreatedAt = messages[0]?.createdAt;
-
-                return (
-                  // eslint-disable-next-line react/no-array-index-key
-                  <div key={i}>
-                    <DateSeparator createdAt={currentCreatedAt} />
-                    {messages.map((m, idx) => {
-                      const previousMessage = messages[idx - 1];
-                      const nextMessage = messages[idx + 1];
-                      const [chainTop, chainBottom] = useMessageGrouping
-                        ? compareMessagesForGrouping(
-                          previousMessage,
-                          m,
-                          nextMessage,
-                        )
-                        : [false, false];
-
-                      if (renderChatItem) {
-                        return (
-                          <div
-                            key={m.messageId || m.reqId}
-                            className="sendbird-msg--scroll-ref"
-                          >
-                            {renderChatItem({
-                              message: m,
-                              highLightedMessageId,
-                              channel: currentGroupChannel,
-                              // hasSeparator: hasSeparator,
-                              onDeleteMessage: deleteMessage,
-                              onUpdateMessage: updateMessage,
-                              onResendMessage: resendMessage,
-                              onScrollToMessage: scrollToMessage,
-                              emojiContainer,
-                              chainTop,
-                              chainBottom,
-                              menuDisabled: disabled,
-                            })}
-                          </div>
-                        );
-                      }
-
-                      return (
-                        <MessageHOC
-                          highLightedMessageId={highLightedMessageId}
-                          renderCustomMessage={renderCustomMessage}
-                          key={m.messageId || m.reqId}
-                          userId={userId}
-                          // show status for pending/failed messages
-                          message={m}
-                          scrollToMessage={scrollToMessage}
-                          currentGroupChannel={currentGroupChannel}
-                          disabled={disabled}
-                          membersMap={membersMap}
-                          chainTop={chainTop}
-                          useReaction={useReaction}
-                          emojiAllMap={emojiAllMap}
-                          emojiContainer={emojiContainer}
-                          editDisabled={editDisabled}
-                          // hasSeparator={hasSeparator}
-                          chainBottom={chainBottom}
-                          updateMessage={updateMessage}
-                          deleteMessage={deleteMessage}
-                          resendMessage={resendMessage}
-                          toggleReaction={toggleReaction}
-                          memoizedEmojiListItems={memoizedEmojiListItems}
-                          onReplyMessage={onReplyMessage}
-                        />
-                      );
-                    })}
-                  </div>
-                );
-              },
-            )}
-            {/* {allMessages.map((m, idx) => {
-              const previousMessage = allMessages[idx - 1];
-              const nextMessage = allMessages[idx + 1];
-              const [chainTop, chainBottom] = useMessageGrouping
-                ? compareMessagesForGrouping(previousMessage, m, nextMessage)
-                : [false, false];
-              const previousMessageCreatedAt = previousMessage && previousMessage.createdAt;
-              const currentCreatedAt = m.createdAt;
-              // https://stackoverflow.com/a/41855608
-              const hasSeparator = !(
-                previousMessageCreatedAt
-                && isSameDay(currentCreatedAt, previousMessageCreatedAt)
-              );
-              if (renderChatItem) {
-                return (
-                  <div
-                    key={m.messageId || m.reqId}
-                    className="sendbird-msg--scroll-ref"
-                  >
-                    {renderChatItem({
-                      message: m,
-                      highLightedMessageId,
-                      channel: currentGroupChannel,
-                      onDeleteMessage: deleteMessage,
-                      onUpdateMessage: updateMessage,
-                      onResendMessage: resendMessage,
-                      onScrollToMessage: scrollToMessage,
-                      emojiContainer,
-                      chainTop,
-                      chainBottom,
-                      hasSeparator,
-                      menuDisabled: disabled,
-                    })}
-                  </div>
-                );
-              }
+          {Array.from(groupMessagesByDate(allMessages).values()).map(
+            (messages, i) => {
+              const currentCreatedAt = messages[0]?.createdAt;
 
               return (
-                <MessageHOC
-                  highLightedMessageId={highLightedMessageId}
-                  renderCustomMessage={renderCustomMessage}
-                  key={m.messageId || m.reqId}
-                  userId={userId}
-                  // show status for pending/failed messages
-                  message={m}
-                  scrollToMessage={scrollToMessage}
-                  currentGroupChannel={currentGroupChannel}
-                  disabled={disabled}
-                  membersMap={membersMap}
-                  chainTop={chainTop}
-                  useReaction={useReaction}
-                  emojiAllMap={emojiAllMap}
-                  emojiContainer={emojiContainer}
-                  editDisabled={editDisabled}
-                  hasSeparator={hasSeparator}
-                  chainBottom={chainBottom}
-                  updateMessage={updateMessage}
-                  deleteMessage={deleteMessage}
-                  resendMessage={resendMessage}
-                  toggleReaction={toggleReaction}
-                  memoizedEmojiListItems={memoizedEmojiListItems}
-                />
+                // eslint-disable-next-line react/no-array-index-key
+                <div key={i}>
+                  <DateSeparator createdAt={currentCreatedAt} />
+                  {messages.map((m, idx) => {
+                    const previousMessage = messages[idx - 1];
+                    const nextMessage = messages[idx + 1];
+                    const [chainTop, chainBottom] = useMessageGrouping
+                      ? compareMessagesForGrouping(
+                        previousMessage,
+                        m,
+                        nextMessage,
+                      )
+                      : [false, false];
+
+                    if (renderChatItem) {
+                      return (
+                        <div
+                          key={m.messageId || m.reqId}
+                          className="sendbird-msg--scroll-ref"
+                        >
+                          {renderChatItem({
+                            message: m,
+                            highLightedMessageId,
+                            channel: currentGroupChannel,
+                            // hasSeparator: hasSeparator,
+                            onDeleteMessage: deleteMessage,
+                            onUpdateMessage: updateMessage,
+                            onResendMessage: resendMessage,
+                            onScrollToMessage: scrollToMessage,
+                            emojiContainer,
+                            chainTop,
+                            chainBottom,
+                            menuDisabled: disabled,
+                          })}
+                        </div>
+                      );
+                    }
+
+                    return (
+                      <MessageHOC
+                        highLightedMessageId={highLightedMessageId}
+                        renderCustomMessage={renderCustomMessage}
+                        key={m.messageId || m.reqId}
+                        userId={userId}
+                        // show status for pending/failed messages
+                        message={m}
+                        scrollToMessage={scrollToMessage}
+                        currentGroupChannel={currentGroupChannel}
+                        disabled={disabled}
+                        membersMap={membersMap}
+                        chainTop={chainTop}
+                        useReaction={useReaction}
+                        emojiAllMap={emojiAllMap}
+                        emojiContainer={emojiContainer}
+                        editDisabled={editDisabled}
+                        // hasSeparator={hasSeparator}
+                        chainBottom={chainBottom}
+                        updateMessage={updateMessage}
+                        deleteMessage={deleteMessage}
+                        resendMessage={resendMessage}
+                        toggleReaction={toggleReaction}
+                        memoizedEmojiListItems={memoizedEmojiListItems}
+                        onReplyMessage={onReplyMessage}
+                      />
+                    );
+                  })}
+                </div>
               );
-            })} */}
-          </div>
+            },
+          )}
         </div>
         {showScrollBot && (
           <div

--- a/src/rogu/smart-components/Conversation/components/MessageHOC.jsx
+++ b/src/rogu/smart-components/Conversation/components/MessageHOC.jsx
@@ -14,6 +14,8 @@ import RemoveMessageModal from './RemoveMessage';
 // import DateSeparator from '../../../ui/DateSeparator';
 import FileViewer from '../../../ui/FileViewer';
 
+import { getClassName } from '../../../../utils';
+
 export default function MessageHoc({
   message,
   userId,
@@ -39,7 +41,7 @@ export default function MessageHoc({
   // const [showEdit, setShowEdit] = useState(false);
   const [showRemove, setShowRemove] = useState(false);
   const [showFileViewer, setShowFileViewer] = useState(false);
-  const [isAnimated, setIsAnimated] = useState(false);
+  const [isHighlighted, setAsHighlighted] = useState(false);
   // const editMessageInputRef = useRef(null);
   const useMessageScrollRef = useRef(null);
 
@@ -47,15 +49,16 @@ export default function MessageHoc({
     if (highLightedMessageId === message.messageId) {
       if (useMessageScrollRef && useMessageScrollRef.current) {
         useMessageScrollRef.current.scrollIntoView({
+          behavior: 'smooth', // iOS Safari incompatible (https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView)
           block: 'center',
           inline: 'center',
         });
         setTimeout(() => {
-          setIsAnimated(true);
+          setAsHighlighted(true);
         }, 500);
       }
     } else {
-      setIsAnimated(false);
+      setAsHighlighted(false);
     }
   }, [highLightedMessageId, useMessageScrollRef.current, message.messageId]);
   const RenderedMessage = useMemo(() => {
@@ -80,24 +83,16 @@ export default function MessageHoc({
     return (
       <div
         ref={useMessageScrollRef}
-        className={`
-          sendbird-msg-hoc sendbird-msg--scroll-ref
-          ${isAnimated ? 'sendbird-msg-hoc__animated' : ''}
-        `}
+        className={getClassName([
+          'rogu-message-hoc',
+          chainBottom ? 'rogu-message-hoc--chain-bottom' : '',
+          isHighlighted ? 'rogu-message-hoc--highlighted' : '',
+        ])}
       >
-        {/* date-separator */}
-        {
-          // hasSeparator && null
-          // <DateSeparator>
-          //   <Label
-          //     type={LabelTypography.CAPTION_2}
-          //     color={LabelColors.ONBACKGROUND_2}
-          //   >
-          //     {format(message.createdAt, 'MMMM dd, yyyy')}
-          //   </Label>
-          // </DateSeparator>
-        }
-        <RenderedMessage message={message} />
+        <RenderedMessage
+          className="rogu-message-hoc__message-content"
+          message={message}
+        />
       </div>
     );
   }
@@ -105,17 +100,14 @@ export default function MessageHoc({
   return (
     <div
       ref={useMessageScrollRef}
-      className={`
-        sendbird-msg-hoc sendbird-msg--scroll-ref
-        ${isAnimated ? 'sendbird-msg-hoc__animated' : ''}
-      `}
-      style={{ marginBottom: '2px' }}
+      className={getClassName([
+        'rogu-message-hoc',
+        chainBottom ? 'rogu-message-hoc--chain-bottom' : '',
+        isHighlighted ? 'rogu-message-hoc--highlighted' : '',
+      ])}
     >
-      {/* date-separator */}
-      {/* {hasSeparator && <DateSeparator createdAt={message.createdAt} />} */}
-      {/* Message */}
       <MessageContent
-        className="sendbird-message-hoc__message-content"
+        className="rogu-message-hoc__message-content"
         userId={userId}
         scrollToMessage={scrollToMessage}
         channel={currentGroupChannel}

--- a/src/rogu/smart-components/Conversation/index.scss
+++ b/src/rogu/smart-components/Conversation/index.scss
@@ -29,68 +29,6 @@
   justify-content: flex-end;
 }
 
-@keyframes sbHighlight {
-  0% {
-    background-color: #fff2b6;
-  }
-
-  99% {
-    background-color: #fff2b6;
-  }
-}
-
-@keyframes sbTextHighlight {
-  0% {
-    color: var(--sendbird-dark-onlight-01);
-  }
-
-  99% {
-    color: var(--sendbird-dark-onlight-01);
-  }
-}
-
-@keyframes sbHighlightBlock {
-  0% {
-    opacity: 0.5;
-    background-color: #fff2b6;
-  }
-
-  99% {
-    opacity: 0.5;
-    background-color: #fff2b6;
-  }
-}
-
-.sendbird-msg-hoc__animated {
-  .sendbird-text-message-item-body,
-  .sendbird-file-message-item-body {
-    animation-name: sbHighlight;
-    animation-duration: 1.6s;
-    animation-fill-mode: forwards;
-  }
-
-  .sendbird-text-message-item-body__message,
-  .sendbird-file-message-item-body__file-name__text {
-    animation-name: sbTextHighlight;
-    animation-duration: 1.6s;
-    animation-fill-mode: forwards;
-  }
-
-  .sendbird-thumbnail-message-item-body .sendbird-thumbnail-message-item-body__image-cover {
-    display: block;
-    animation-name: sbHighlightBlock;
-    animation-duration: 1.6s;
-    animation-fill-mode: forwards;
-  }
-
-  .sendbird-og-message-item-body .sendbird-og-message-item-body__cover {
-    display: block;
-    animation-name: sbHighlightBlock;
-    animation-duration: 1.6s;
-    animation-fill-mode: forwards;
-  }
-}
-
 .rogu-conversation__scroll-container {
   display: flex;
   height: 100%;
@@ -110,5 +48,52 @@
 
   .rogu-conversation__typing-indicator {
     margin-bottom: 4px;
+  }
+}
+
+.rogu-message-hoc {
+  padding-right: 24px;
+  padding-left: 24px;
+  background: transparent;
+  transition: background-color 400ms ease-in;
+
+  &.rogu-message-hoc--highlighted {
+    animation:
+      highlightFadeIn 300ms forwards,
+      highlightFadeOut 300ms 3s forwards;
+
+    &.rogu-message-hoc--chain-bottom {
+      padding-bottom: 8px;
+
+      .rogu-message-hoc__message-content {
+        margin-bottom: 0;
+      }
+    }
+  }
+}
+
+$highlightColor: rgba(46, 180, 192, 0.2);
+
+@keyframes highlightFadeIn {
+  from {
+    padding-top: 0;
+    background: transparent;
+  }
+
+  to {
+    padding-top: 8px;
+    background: $highlightColor;
+  }
+}
+
+@keyframes highlightFadeOut {
+  from {
+    padding-top: 8px;
+    background: $highlightColor;
+  }
+
+  to {
+    background: transparent;
+    padding-top: 0;
   }
 }

--- a/src/rogu/ui/MessageContent/index.tsx
+++ b/src/rogu/ui/MessageContent/index.tsx
@@ -1,3 +1,11 @@
+/**
+ * TODO:
+ *
+ * [x] Add created at to the metaarray
+ * [ ] Handle click, scroll to the replied message
+ * [ ] Add highlight upon click
+ */
+
 import React, { ReactElement, useRef, useContext } from 'react';
 import { GroupChannel, AdminMessage, UserMessage, FileMessage } from 'sendbird';
 import Label, { LabelTypography, LabelColors } from '../Label';
@@ -75,7 +83,7 @@ export default function MessageContent({
   userId,
   // useReaction = false,
   // useReplying,
-  // scrollToMessage,
+  scrollToMessage,
   showEdit,
   showFileViewer,
   showRemove,
@@ -109,11 +117,6 @@ Props): ReactElement {
   if (message?.isAdminMessage?.() || message?.messageType === 'admin') {
     return <ClientAdminMessage message={message} />;
   }
-
-  const onScrollToMessage = () => {
-    //TODO: integrate onScrollToMessage
-    // scrollToMessage(message.createdAt, getParentMessageId(message));
-  };
 
   return (
     <div
@@ -191,7 +194,7 @@ Props): ReactElement {
                 <TextMessageItemBody
                   isByMe={isByMe}
                   message={message as UserMessage}
-                  onClickRepliedMessage={onScrollToMessage}
+                  onClickRepliedMessage={scrollToMessage}
                 />
               )}
               {isOGMessage(message as UserMessage) && (
@@ -228,6 +231,7 @@ Props): ReactElement {
                     getOutgoingMessageState(channel, message) !==
                     OutgoingMessageStates.PENDING
                   }
+                  onClickRepliedMessage={scrollToMessage}
                 />
               )}
               {getUIKitMessageType(message as FileMessage) ===

--- a/src/rogu/ui/MessageInput/index.jsx
+++ b/src/rogu/ui/MessageInput/index.jsx
@@ -178,9 +178,9 @@ const MessageInput = React.forwardRef((props, ref) => {
 
       if (repliedMessage) {
         let repliedMessageBody = repliedMessage.message;
+        let repliedMessageMediaUrl = '';
         let repliedMessageMimeType = '*';
         let repliedMessageType = REPLIED_MESSAGE_TYPE.Text;
-        let repliedMessageMediaUrl = '';
 
         if (isThumbnailMessage(repliedMessage)) {
           repliedMessageMimeType = repliedMessage.type;
@@ -216,10 +216,11 @@ const MessageInput = React.forwardRef((props, ref) => {
         }
         onFileUpload(modifiedFile, {
           parentMessageBody: repliedMessageBody,
+          parentMessageCreatedAt: repliedMessage.createdAt,
           parentMessageId: repliedMessage.messageId,
+          parentMessageMediaUrl: repliedMessageMediaUrl,
           parentMessageMimeType: repliedMessageMimeType,
           parentMessageNickname: repliedMessage.sender?.nickname,
-          parentMessageMediaUrl: repliedMessageMediaUrl,
           parentMessageType: repliedMessageType,
         });
       } else {
@@ -228,9 +229,9 @@ const MessageInput = React.forwardRef((props, ref) => {
     } else if (inputValue && inputValue.trim().length > 0) {
       if (repliedMessage) {
         let repliedMessageBody = repliedMessage.message;
+        let repliedMessageMediaUrl = '';
         let repliedMessageMimeType = '*';
         let repliedMessageType = REPLIED_MESSAGE_TYPE.Text;
-        let repliedMessageMediaUrl = '';
 
         if (isThumbnailMessage(repliedMessage)) {
           repliedMessageMimeType = repliedMessage.type;
@@ -267,10 +268,11 @@ const MessageInput = React.forwardRef((props, ref) => {
 
         onSendMessage({
           parentMessageBody: repliedMessageBody,
+          parentMessageCreatedAt: repliedMessage.createdAt,
           parentMessageId: repliedMessage.messageId,
+          parentMessageMediaUrl: repliedMessageMediaUrl,
           parentMessageMimeType: repliedMessageMimeType,
           parentMessageNickname: repliedMessage.sender?.nickname,
-          parentMessageMediaUrl: repliedMessageMediaUrl,
           parentMessageType: repliedMessageType,
         });
       } else {

--- a/src/rogu/ui/RepliedMessageItemBody/index.tsx
+++ b/src/rogu/ui/RepliedMessageItemBody/index.tsx
@@ -1,12 +1,3 @@
-/**
- * TODO
- * [x] Handle normal text message
- * [x] Handle file message
- * [ ] Handle assignment message
- * [ ] Handle material message
- * [ ] Handle image message
- * [ ] Handle video message
- */
 import React from 'react';
 
 import RepliedAssignmentMessageItemBody from '../RepliedAssignmentMessageItemBody';
@@ -53,7 +44,7 @@ export function RepliedMessageItemBody({
           isByMe={isByMe}
           mimeType={mimeType}
           nickname={nickname}
-          onClick={() => console.log('Scroll to the message')}
+          onClick={onClick}
         />
       );
     case RepliedMessageType.Image:
@@ -64,7 +55,7 @@ export function RepliedMessageItemBody({
           isByMe={isByMe}
           mimeType={mimeType}
           nickname={nickname}
-          onClick={() => console.log('Scroll to the message')}
+          onClick={onClick}
           mediaUrl={mediaUrl}
         />
       );
@@ -72,7 +63,7 @@ export function RepliedMessageItemBody({
       return (
         <RepliedAssignmentMessageItemBody
           body={body}
-          isByMe={isByMe} // always false to match the styling
+          isByMe={isByMe}
           nickname={nickname}
           onClick={onClick}
         />
@@ -81,7 +72,7 @@ export function RepliedMessageItemBody({
       return (
         <RepliedMaterialMessageItemBody
           body={body}
-          isByMe={isByMe} // always false to match the styling
+          isByMe={isByMe}
           nickname={nickname}
           onClick={onClick}
         />

--- a/src/rogu/ui/TextMessageItemBody/index.tsx
+++ b/src/rogu/ui/TextMessageItemBody/index.tsx
@@ -14,9 +14,7 @@ interface Props {
   className?: string | Array<string>;
   isByMe?: boolean;
   message: UserMessage;
-  onClickRepliedMessage?: (
-    e: React.MouseEvent<HTMLDivElement, MouseEvent>
-  ) => void;
+  onClickRepliedMessage?: (createdAt: number, messageId: number) => void;
 }
 
 export default function TextMessageItemBody({
@@ -25,12 +23,14 @@ export default function TextMessageItemBody({
   message,
   onClickRepliedMessage,
 }: Props): ReactElement {
-  let repliedMessageNickname = '';
-  let repliedMessageBody = '';
-  let repliedMessageMimeType = '*';
-  let repliedMessageType = RepliedMessageType.Text;
   let messageBody = message.message;
+  let repliedMessageBody = '';
+  let repliedMessageCreatedAt = 0;
+  let repliedMessageId = '';
   let repliedMessageMediaUrl = '';
+  let repliedMessageMimeType = '*';
+  let repliedMessageNickname = '';
+  let repliedMessageType = RepliedMessageType.Text;
 
   const hasRepliedMessage = isReplyingMessage(message);
 
@@ -43,13 +43,28 @@ export default function TextMessageItemBody({
 
     const repliedMessage = metaArraysToRepliedMessage(message.metaArrays);
 
-    repliedMessageNickname = parentMessageNickname;
-    repliedMessageBody = parentMessageBody;
-    repliedMessageMimeType = repliedMessage.parentMessageMimeType;
-    repliedMessageType = repliedMessage.parentMessageType;
     messageBody = originalMessage;
+    repliedMessageBody = parentMessageBody;
+    repliedMessageCreatedAt = repliedMessage.parentMessageCreatedAt;
+    repliedMessageId = repliedMessage.parentMessageId;
     repliedMessageMediaUrl = repliedMessage.parentMessageMediaUrl;
+    repliedMessageMimeType = repliedMessage.parentMessageMimeType;
+    repliedMessageNickname = parentMessageNickname;
+    repliedMessageType = repliedMessage.parentMessageType;
   }
+
+  const handleScrollToRepliedMessage = () => {
+    if (
+      hasRepliedMessage &&
+      onClickRepliedMessage &&
+      typeof onClickRepliedMessage === 'function'
+    ) {
+      onClickRepliedMessage(
+        Number(repliedMessageCreatedAt),
+        Number(repliedMessageId)
+      );
+    }
+  };
 
   return (
     <>
@@ -60,7 +75,7 @@ export default function TextMessageItemBody({
           mimeType={repliedMessageMimeType}
           nickname={repliedMessageNickname}
           type={repliedMessageType}
-          onClick={onClickRepliedMessage}
+          onClick={() => handleScrollToRepliedMessage()}
           mediaUrl={repliedMessageMediaUrl}
         />
       )}

--- a/src/rogu/ui/ThumbnailMessageItemBody/index.tsx
+++ b/src/rogu/ui/ThumbnailMessageItemBody/index.tsx
@@ -16,9 +16,7 @@ interface Props {
   mouseHover?: boolean;
   showFileViewer?: (bool: boolean) => void;
   isClickable: boolean;
-  onClickRepliedMessage?: (
-    e: React.MouseEvent<HTMLDivElement, MouseEvent>
-  ) => void;
+  onClickRepliedMessage?: (createdAt: number, messageId: number) => void;
 }
 
 export default function ThumbnailMessageItemBody({
@@ -38,21 +36,33 @@ export default function ThumbnailMessageItemBody({
   const renderRepliedMessage = () => {
     const {
       parentMessageBody,
+      parentMessageCreatedAt,
+      parentMessageId,
+      parentMessageMediaUrl,
       parentMessageMimeType,
       parentMessageNickname,
       parentMessageType,
-      parentMessageMediaUrl,
     } = metaArraysToRepliedMessage(message.metaArrays);
 
     return (
       <RepliedMessageItemBody
         body={parentMessageBody}
         isByMe={isByMe}
+        mediaUrl={parentMessageMediaUrl}
         mimeType={parentMessageMimeType}
         nickname={parentMessageNickname}
         type={parentMessageType}
-        onClick={onClickRepliedMessage}
-        mediaUrl={parentMessageMediaUrl}
+        onClick={() => {
+          if (
+            onClickRepliedMessage &&
+            typeof onClickRepliedMessage === 'function'
+          ) {
+            onClickRepliedMessage(
+              Number(parentMessageCreatedAt),
+              Number(parentMessageId)
+            );
+          }
+        }}
       />
     );
   };

--- a/src/rogu/utils/repliedMessage.ts
+++ b/src/rogu/utils/repliedMessage.ts
@@ -27,12 +27,13 @@ export const REPLIED_MESSAGE_TYPE = {
 
 export type RepliedMessage = {
   originalMessage?: string;
-  parentMessageId: string;
   parentMessageBody: string;
+  parentMessageCreatedAt: number;
+  parentMessageId: string;
+  parentMessageMediaUrl?: string;
   parentMessageMimeType?: string;
   parentMessageNickname: string;
   parentMessageType: RepliedMessageType;
-  parentMessageMediaUrl?: string;
 };
 
 export const formatedStringToRepliedMessage = (
@@ -55,6 +56,7 @@ export const formatedStringToRepliedMessage = (
     parentMessageBody,
     parentMessageNickname,
     parentMessageType: RepliedMessageType.Text,
+    parentMessageCreatedAt: 0,
   };
 };
 
@@ -118,11 +120,12 @@ export const metaArraysToRepliedMessage = (
       return repliedMessage;
     },
     {
-      parentMessageId: '',
       parentMessageBody: '',
+      parentMessageCreatedAt: 0,
+      parentMessageId: '',
+      parentMessageMediaUrl: '',
+      parentMessageMimeType: '*',
       parentMessageNickname: '',
       parentMessageType: RepliedMessageType.Text,
-      parentMessageMimeType: '*',
-      parentMessageMediaUrl: '',
     }
   );


### PR DESCRIPTION
> This project is a forked version of the [Sendbird UI Kit](https://github.com/sendbird/sendbird-uikit-react) to match with the Ruangguru's internal requirements. Therefore, it is not yet set up to accept pull requests from external contributors. But you can always freely create a forked version from this repository to match your own requirements.

## Related Issue

[RKLS-1079](https://ruanggguru.atlassian.net/browse/RKLS-1079)

## Description Of Changes

In this PR, I add functionality to scroll to and highlight the replied message upon a click event.
Basically, we need to handle 2 use cases:
   - The replied message is fetched and rendered in the dom
   - The replied message is not fetched and not rendered in the dom (because it is too far behind today's timestamp)

### Technical Approach
- Store the createdAt of the replied message in the `sorted_metaarray` (i.e. `parentMessageCreatedAt`);
- Use the existing hook, i.e. `useScrollToMessage` that return a callback with `createdAt` and `messageId` args. Pass these callback to the `RepliedMessageItemBody` via `onClickRepliedMessage` prop.
- Upon clicking, if the message is not fetched and not rendered in the dom, the app will automatically fetch the messages with the specific timestamp (i.e. `createdAt`), render the messages, and scroll to the replied message.
- To add a highlight effect, we conditionally insert the `rogu-message-hoc--highlighted` class name to the `MessageHOC` if the `messageId` is equal to `highlightedMessageId`


### Additional Changes

None

### Demo

- The replied message is fetched and rendered in the dom:

   https://user-images.githubusercontent.com/24476578/141730735-7e6c2bf7-898f-42bb-addb-e8126f0adc6c.mp4


- The replied message is not fetched and not rendered in the dom (because it is too far behind today's timestamp):

   https://user-images.githubusercontent.com/24476578/141731814-c6796e39-7a49-4bb3-8394-2cd4a72a038b.mp4


