### PR TITLE
feat: add message reply with link

### DIFF
--- a/__mocks__/messagesMock.js
+++ b/__mocks__/messagesMock.js
@@ -143,16 +143,20 @@ export const VIDEO_MESSAGE = {
   ...IMAGE_MESSAGE,
   size: 771699,
   type: 'video/mp4',
-  url: 'https://sendbird-upload.s3.amazonaws.com/D74864D6-2283-48E1-8381-89719216DC7F/upload/n/360a8dad320646298788f68a0d417c1c.mp4',
-  plainUrl: 'https://sendbird-upload.s3.amazonaws.com/D74864D6-2283-48E1-8381-89719216DC7F/upload/n/360a8dad320646298788f68a0d417c1c.mp4',
+  url:
+    'https://sendbird-upload.s3.amazonaws.com/D74864D6-2283-48E1-8381-89719216DC7F/upload/n/360a8dad320646298788f68a0d417c1c.mp4',
+  plainUrl:
+    'https://sendbird-upload.s3.amazonaws.com/D74864D6-2283-48E1-8381-89719216DC7F/upload/n/360a8dad320646298788f68a0d417c1c.mp4',
 };
 
 export const GIF_MESSAGE = {
   ...IMAGE_MESSAGE,
   size: 2676798,
   type: 'image/gif',
-  url: 'https://sendbird-upload.s3.amazonaws.com/D74864D6-2283-48E1-8381-89719216DC7F/upload/n/65bd937a3a4641bb98c0fe878eabafa3.gif',
-  plainUrl: 'https://sendbird-upload.s3.amazonaws.com/D74864D6-2283-48E1-8381-89719216DC7F/upload/n/65bd937a3a4641bb98c0fe878eabafa3.gif',
+  url:
+    'https://sendbird-upload.s3.amazonaws.com/D74864D6-2283-48E1-8381-89719216DC7F/upload/n/65bd937a3a4641bb98c0fe878eabafa3.gif',
+  plainUrl:
+    'https://sendbird-upload.s3.amazonaws.com/D74864D6-2283-48E1-8381-89719216DC7F/upload/n/65bd937a3a4641bb98c0fe878eabafa3.gif',
 };
 
 export const FILE_MESSAGE = {
@@ -214,4 +218,24 @@ export const FILE_MESSAGE_PDF = {
     'https://sendbird-upload.s3.amazonaws.com/D74864D6-2283-48E1-8381-89719216DC7F/upload/n/ba3f15a990f84cef9f87f2d88fd30712.pdf',
   size: 8900,
   type: 'application/pdf',
+};
+
+export const OG_MESSAGE = {
+  ...BASIC_MESSAGE,
+  message: 'Visit https://suliskh.com!',
+  ogMetaData: {
+    title: 'Kukuh Sulistyo — Insinyur Perangkat Lunak',
+    url: 'https://suliskh.com',
+    description:
+      'Insinyur perangkat lunak berfokus di web. Tertarik dengan design system dan aksesibilitas',
+    defaultImage: {
+      url:
+        'https://ik.imagekit.io/dnha0dbp86x/suliskh_com/Home_1__8lvqRSrdOB.png',
+      secureUrl: null,
+      type: null,
+      width: 0,
+      height: 0,
+      alt: null,
+    },
+  },
 };

--- a/src/rogu/ui/MessageContent/index.tsx
+++ b/src/rogu/ui/MessageContent/index.tsx
@@ -201,6 +201,7 @@ Props): ReactElement {
                 <OGMessageItemBody
                   message={message as UserMessage}
                   isByMe={isByMe}
+                  onClickRepliedMessage={scrollToMessage}
                 />
               )}
               {isAssignmentMessage(message.customType) && (

--- a/src/rogu/ui/OGMessageItemBody/__tests__/OGMessageItemBody.spec.js
+++ b/src/rogu/ui/OGMessageItemBody/__tests__/OGMessageItemBody.spec.js
@@ -1,14 +1,14 @@
 import React from 'react';
-import {shallow} from 'enzyme';
 import renderer from 'react-test-renderer';
 
-import OGMessageItemBody from "../index";
+import OGMessageItemBody from '../index';
+
+import { OG_MESSAGE } from '../../../../../__mocks__/messagesMock';
 
 describe('OGMessageItemBody', () => {
-  it('should do a snapshot test of the OGMessageItemBody DOM', function() {
-    const text = "example-text";
+  it('should do a snapshot test of the OGMessageItemBody DOM', function () {
     const component = renderer.create(
-      <OGMessageItemBody />,
+      <OGMessageItemBody message={OG_MESSAGE} />
     );
     let tree = component.toJSON();
     expect(tree).toMatchSnapshot();

--- a/src/rogu/ui/OGMessageItemBody/__tests__/__snapshots__/OGMessageItemBody.spec.js.snap
+++ b/src/rogu/ui/OGMessageItemBody/__tests__/__snapshots__/OGMessageItemBody.spec.js.snap
@@ -10,6 +10,8 @@ exports[`OGMessageItemBody should do a snapshot test of the OGMessageItemBody DO
     <div
       className="rogu-og-message-item-body__og-container"
       onClick={[Function]}
+      role="button"
+      tabIndex={0}
     >
       <div
         className="rogu-og-message-item-body__og-thumbnail"
@@ -29,7 +31,7 @@ exports[`OGMessageItemBody should do a snapshot test of the OGMessageItemBody DO
             className="sendbird-image-renderer__image"
             style={
               Object {
-                "backgroundImage": "url()",
+                "backgroundImage": "url(https://ik.imagekit.io/dnha0dbp86x/suliskh_com/Home_1__8lvqRSrdOB.png)",
                 "backgroundPosition": "center",
                 "backgroundRepeat": "no-repeat",
                 "backgroundSize": "cover",
@@ -43,24 +45,64 @@ exports[`OGMessageItemBody should do a snapshot test of the OGMessageItemBody DO
             }
           />
           <img
-            alt=""
+            alt={null}
             className="sendbird-image-renderer__hidden-image-loader"
             onError={[Function]}
             onLoad={[Function]}
-            src=""
+            src="https://ik.imagekit.io/dnha0dbp86x/suliskh_com/Home_1__8lvqRSrdOB.png"
           />
         </div>
       </div>
       <div
         className="rogu-og-message-item-body__description"
-      />
+      >
+        <span
+          className="rogu-og-message-item-body__description__title sendbird-label sendbird-label--subtitle-2 sendbird-label--color-onbackground-1"
+        >
+          Kukuh Sulistyo — Insinyur Perangkat Lunak
+        </span>
+        <span
+          className="rogu-og-message-item-body__description__description sendbird-label sendbird-label--body-2 sendbird-label--color-onbackground-1"
+        >
+          Insinyur perangkat lunak berfokus di web. Tertarik dengan design system dan aksesibilitas
+        </span>
+        <span
+          className="rogu-og-message-item-body__description__url sendbird-label sendbird-label--caption-3 sendbird-label--color-onbackground-2"
+        >
+          https://suliskh.com
+        </span>
+      </div>
     </div>
   </div>
   <div
-    className="rogu-og-message-item-body__text-bubble"
-  />
-  <div
-    className="rogu-og-message-item-body__cover"
-  />
+    className=" rogu-clamped-message-item-body  rogu-clamped-message-item-body--incoming   "
+  >
+    <div
+      className="rogu-clamped-message-item-body__inner"
+    >
+      <span
+        className="rogu-text-message-item-body__message sendbird-label sendbird-label--body-1 sendbird-label--color-onbackground-1"
+      >
+        Visit 
+      </span>
+      <a
+        className="rogu-text-message-item-body__message rogu-link-label sendbird-label--color-secondary-3"
+        href="https://suliskh.com"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        <span
+          className="rogu-link-label__label sendbird-label sendbird-label--body-1 sendbird-label--color-secondary-3"
+        >
+          https://suliskh.com
+        </span>
+      </a>
+      <span
+        className="rogu-text-message-item-body__message sendbird-label sendbird-label--body-1 sendbird-label--color-onbackground-1"
+      >
+        !
+      </span>
+    </div>
+  </div>
 </div>
 `;

--- a/src/rogu/ui/OGMessageItemBody/index.scss
+++ b/src/rogu/ui/OGMessageItemBody/index.scss
@@ -8,20 +8,11 @@
   min-width: 320px;
   max-width: 400px;
 
-  .rogu-og-message-item-body__text-bubble {
-    position: relative;
-    word-break: break-all;
-    margin-top: 8px;
-
-    .rogu-og-message-item-body__text-bubble__message {
-      display: inline;
-    }
-  }
-
   .rogu-og-message-item-body__og-wrapper {
     padding: 8px;
     display: flex;
     border-radius: 4px;
+    margin-bottom: 8px;
   }
 
   .rogu-og-message-item-body__og-container {
@@ -124,15 +115,5 @@
         }
       }
     }
-  }
-
-  .rogu-og-message-item-body__cover {
-    display: none;
-    position: absolute;
-    top: 0%;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    border-radius: 16px 16px 0 0;
   }
 }

--- a/src/rogu/ui/OGMessageItemBody/index.tsx
+++ b/src/rogu/ui/OGMessageItemBody/index.tsx
@@ -1,173 +1,196 @@
-import React, { ReactElement, useContext } from 'react';
+import React, { ReactElement } from 'react';
 import { UserMessage } from 'sendbird';
+
 import './index.scss';
 
-import LinkLabel from '../../../ui/LinkLabel';
 import ImageRenderer from '../../../ui/ImageRenderer';
-
-import {
-  getClassName,
-  isEditedMessage,
-  isUrl,
-} from '../../../utils';
-import uuidv4 from '../../../utils/uuid';
-import { LocalizationContext } from '../../../lib/LocalizationContext';
 
 import Label, { LabelTypography, LabelColors } from '../Label';
 import Icon, { IconTypes, IconColors } from '../Icon';
-
 import IconButton from '../IconButton';
+import ClampedTextMessageItemBody from '../ClampedMessageItemBody';
+import RepliedMessageItemBody from '../RepliedMessageItemBody';
+
+import { getClassName } from '../../../utils';
+
+import {
+  formatedStringToRepliedMessage,
+  isReplyingMessage,
+  metaArraysToRepliedMessage,
+  RepliedMessageType,
+} from '../../utils';
 
 interface Props {
   className?: string | Array<string>;
-  message: UserMessage;
   isByMe?: boolean;
-  mouseHover?: boolean;
   isOnPreview?: boolean;
+  message: UserMessage;
+  mouseHover?: boolean;
+  onClickRepliedMessage?: (createdAt: number, messageId: number) => void;
   onClosePreview?: () => void;
 }
 
 export default function OGMessageItemBody({
   className,
-  message,
   isByMe = false,
-  mouseHover = false,
   isOnPreview = false,
+  message,
+  mouseHover = false,
+  onClickRepliedMessage,
   onClosePreview,
 }: Props): ReactElement {
-  const { stringSet } = useContext(LocalizationContext);
-  const openOGUrl = (): void => {
+  let messageBody = message.message;
+  let repliedMessageBody = '';
+  let repliedMessageCreatedAt = 0;
+  let repliedMessageId = '';
+  let repliedMessageMediaUrl = '';
+  let repliedMessageMimeType = '*';
+  let repliedMessageNickname = '';
+  let repliedMessageType = RepliedMessageType.Text;
+
+  const hasRepliedMessage = isReplyingMessage(message);
+
+  if (hasRepliedMessage) {
+    const {
+      originalMessage,
+      parentMessageBody,
+      parentMessageNickname,
+    } = formatedStringToRepliedMessage(messageBody);
+
+    const repliedMessage = metaArraysToRepliedMessage(message.metaArrays);
+
+    messageBody = originalMessage;
+    repliedMessageBody = parentMessageBody;
+    repliedMessageCreatedAt = repliedMessage.parentMessageCreatedAt;
+    repliedMessageId = repliedMessage.parentMessageId;
+    repliedMessageMediaUrl = repliedMessage.parentMessageMediaUrl;
+    repliedMessageMimeType = repliedMessage.parentMessageMimeType;
+    repliedMessageNickname = parentMessageNickname;
+    repliedMessageType = repliedMessage.parentMessageType;
+  }
+
+  const handleScrollToRepliedMessage = () => {
+    if (
+      hasRepliedMessage &&
+      onClickRepliedMessage &&
+      typeof onClickRepliedMessage === 'function'
+    ) {
+      onClickRepliedMessage(
+        Number(repliedMessageCreatedAt),
+        Number(repliedMessageId)
+      );
+    }
+  };
+
+  const handleOpenOGUrl = (): void => {
     if (message?.ogMetaData?.url) window.open(message?.ogMetaData?.url);
   };
 
   return (
-    <div className={getClassName([
-      className,
-      'rogu-og-message-item-body',
-      isByMe ? 'rogu-og-message--outgoing' : 'rogu-og-message--incoming',
-      isOnPreview ? 'rogu-og-message-item-body--preview' : '',
-      mouseHover ? 'mouse-hover' : '',
-      message?.reactions?.length > 0 ? 'rogu-og-message-reactions' : '',
-    ])}>
+    <div
+      className={getClassName([
+        className,
+        'rogu-og-message-item-body',
+        isByMe ? 'rogu-og-message--outgoing' : 'rogu-og-message--incoming',
+        isOnPreview ? 'rogu-og-message-item-body--preview' : '',
+        mouseHover ? 'mouse-hover' : '',
+        message?.reactions?.length > 0 ? 'rogu-og-message-reactions' : '',
+      ])}
+    >
+      {/* Replied message */}
+      {hasRepliedMessage && (
+        <RepliedMessageItemBody
+          body={repliedMessageBody}
+          isByMe={isByMe}
+          mimeType={repliedMessageMimeType}
+          nickname={repliedMessageNickname}
+          type={repliedMessageType}
+          onClick={() => handleScrollToRepliedMessage()}
+          mediaUrl={repliedMessageMediaUrl}
+        />
+      )}
 
-      <div className="rogu-og-message-item-body__og-wrapper" >
-        <div className="rogu-og-message-item-body__og-container" onClick={openOGUrl}>
+      {/* OG preview */}
+      <div className="rogu-og-message-item-body__og-wrapper">
         <div
-          className="rogu-og-message-item-body__og-thumbnail"          
+          className="rogu-og-message-item-body__og-container"
+          onClick={handleOpenOGUrl}
+          role="button"
+          tabIndex={0}
         >
-          <ImageRenderer
-            className="rogu-og-message-item-body__og-thumbnail__image"
-            url={message?.ogMetaData?.defaultImage?.url || ''}
-            alt={message?.ogMetaData?.defaultImage?.alt}
-            width="60px"
-            height="60px"
-            defaultComponent={(
-              <div className="rogu-og-message-item-body__og-thumbnail__place-holder">
-                <Icon
-                  className="rogu-og-message-item-body__og-thumbnail__place-holder__icon"
-                  type={IconTypes.THUMBNAIL_NONE}
-                  width="60px"
-                  height="60px"
-                />
-              </div>
+          <div className="rogu-og-message-item-body__og-thumbnail">
+            <ImageRenderer
+              className="rogu-og-message-item-body__og-thumbnail__image"
+              url={message?.ogMetaData?.defaultImage?.url || ''}
+              alt={message?.ogMetaData?.defaultImage?.alt}
+              width="60px"
+              height="60px"
+              defaultComponent={
+                <div className="rogu-og-message-item-body__og-thumbnail__place-holder">
+                  <Icon
+                    className="rogu-og-message-item-body__og-thumbnail__place-holder__icon"
+                    type={IconTypes.THUMBNAIL_NONE}
+                    width="60px"
+                    height="60px"
+                  />
+                </div>
+              }
+            />
+          </div>
+          <div className="rogu-og-message-item-body__description">
+            {message?.ogMetaData?.title && (
+              <Label
+                className="rogu-og-message-item-body__description__title"
+                type={LabelTypography.SUBTITLE_2}
+                color={LabelColors.ONBACKGROUND_1}
+              >
+                {message.ogMetaData.title}
+              </Label>
             )}
-          />
-        </div>
-        <div
-          className="rogu-og-message-item-body__description"          
-        >
-          {message?.ogMetaData?.title && (
-            <Label
-              className="rogu-og-message-item-body__description__title"
-              type={LabelTypography.SUBTITLE_2}
-              color={LabelColors.ONBACKGROUND_1}
-            >
-              {message.ogMetaData.title}
-            </Label>
-          )}
-          {message?.ogMetaData?.description && (
-            <Label
-              className="rogu-og-message-item-body__description__description"
-              type={LabelTypography.BODY_2}
-              color={LabelColors.ONBACKGROUND_1}
-            >
-              {message.ogMetaData.description}
-            </Label>
-          )}
-          {message?.ogMetaData?.url && (
-            <Label
-              className="rogu-og-message-item-body__description__url"
-              type={LabelTypography.CAPTION_3}
-              color={LabelColors.ONBACKGROUND_2}
-            >
-              {message.ogMetaData.url}
-            </Label>
-          )}
-        </div>
+            {message?.ogMetaData?.description && (
+              <Label
+                className="rogu-og-message-item-body__description__description"
+                type={LabelTypography.BODY_2}
+                color={LabelColors.ONBACKGROUND_1}
+              >
+                {message.ogMetaData.description}
+              </Label>
+            )}
+            {message?.ogMetaData?.url && (
+              <Label
+                className="rogu-og-message-item-body__description__url"
+                type={LabelTypography.CAPTION_3}
+                color={LabelColors.ONBACKGROUND_2}
+              >
+                {message.ogMetaData.url}
+              </Label>
+            )}
+          </div>
         </div>
 
-        {
-          isOnPreview && <IconButton
-          className="sendbird-chat-header__right__search"
-          width="32px"
-          height="32px"
-          onClick={onClosePreview}
-        >
-          <Icon
-            type={IconTypes.CLOSE}
-            fillColor={IconColors.ON_BACKGROUND_1}
-            width="24px"
-            height="24px"
-          />
-        </IconButton>
-        }
-
-        
-
+        {isOnPreview && (
+          <IconButton
+            className="sendbird-chat-header__right__search"
+            width="32px"
+            height="32px"
+            onClick={onClosePreview}
+          >
+            <Icon
+              type={IconTypes.CLOSE}
+              fillColor={IconColors.ON_BACKGROUND_1}
+              width="24px"
+              height="24px"
+            />
+          </IconButton>
+        )}
       </div>
-      
-      
-      
-      <div className="rogu-og-message-item-body__text-bubble">
-        {
-          message?.message.split(' ').map((word: string) => (
-            isUrl(word)
-              ? (
-                <LinkLabel
-                  className="rogu-og-message-item-body__text-bubble__message"
-                  key={uuidv4()}
-                  src={word}
-                  type={LabelTypography.BODY_1}
-                  color={isByMe ? LabelColors.ONBACKGROUND_1 : LabelColors.SECONDARY_3}
-                >
-                  {word}
-                </LinkLabel>
-              )
-              : (
-                <Label
-                  className="rogu-og-message-item-body__text-bubble__message"
-                  key={uuidv4()}
-                  type={LabelTypography.BODY_1}
-                  color={LabelColors.ONBACKGROUND_1}
-                >
-                  {word + ' '}
-                </Label>
-              )
-          ))
-        }
-        {
-          isEditedMessage(message) && (
-            <Label
-              className="rogu-og-message-item-body__text-bubble__message"
-              type={LabelTypography.BODY_1}
-              color={isByMe ? LabelColors.ONCONTENT_2 : LabelColors.ONBACKGROUND_2}
-            >
-              {` ${stringSet.MESSAGE_EDITED} `}
-            </Label>
-          )
-        }
-      </div>
-      <div className="rogu-og-message-item-body__cover" />
+
+      {/* Message body */}
+      <ClampedTextMessageItemBody
+        className={className}
+        isByMe={isByMe}
+        content={messageBody}
+      />
     </div>
   );
 }

--- a/src/rogu/ui/OGMessageItemBody/stories/OGMessageItemBody.stories.js
+++ b/src/rogu/ui/OGMessageItemBody/stories/OGMessageItemBody.stories.js
@@ -1,35 +1,34 @@
 import React from 'react';
-import OGMessageItemBody from '../index.tsx';
 
-const mockMessage = () => {
-  const obj = {
-    message: 'go to this link sendbird.com it will be usefull to you!!',
-    ogMetaData: {
-      title: 'I am Title',
-      description: 'I\'m description I\'m description I\'m description I\'m description ',
-      url: 'https://sendbird.com/',
-      defaultImage: {
-        url: 'https://static.sendbird.com/sample/profiles/profile_12_512px.png',
-        alt: 'test',
-      },
-    },
-    sender: {
-      profileUrl: 'https://static.sendbird.com/sample/profiles/profile_12_512px.png',
-      nickname: 'Hoonying',
-    },
-    createdAt: 2000000,
-  };
-  
-  return obj;
-};
+import OGMessageItemBody from '../index.tsx';
+import SendbirdProvider from '../../../../lib/Sendbird';
+
+import COLOR_SET from '../../../../../__mocks__/themeMock';
+import STRING_SET from '../../../../../__mocks__/localizationMock';
+import { OG_MESSAGE } from '../../../../../__mocks__/messagesMock';
 
 export default { title: 'ruangkelas/UI Components/OGMessageItemBody' };
 
 export const withText = () => (
   <>
-    <OGMessageItemBody message={mockMessage()} isByMe />
+    <SendbirdProvider
+      appId="dummy"
+      userID="dummy"
+      colorSet={COLOR_SET}
+      stringSet={STRING_SET}
+    >
+      <OGMessageItemBody message={OG_MESSAGE} isByMe />
+    </SendbirdProvider>
     <br />
     <br />
-    <OGMessageItemBody message={mockMessage()} isByMe={false} />
+
+    <SendbirdProvider
+      appId="dummy"
+      userID="dummy"
+      colorSet={COLOR_SET}
+      stringSet={STRING_SET}
+    >
+      <OGMessageItemBody message={OG_MESSAGE} isByMe={false} />
+    </SendbirdProvider>
   </>
 );


### PR DESCRIPTION
> This project is a forked version of the [Sendbird UI Kit](https://github.com/sendbird/sendbird-uikit-react) to match with the Ruangguru's internal requirements. Therefore, it is not yet set up to accept pull requests from external contributors. But you can always freely create a forked version from this repository to match your own requirements.

## Related Issue

[RKLS-1017](https://ruanggguru.atlassian.net/browse/RKLS-1017)

This PR will also fixes [RKLS-1075](https://ruanggguru.atlassian.net/browse/RKLS-1075) and [RKLS-1123](https://ruanggguru.atlassian.net/browse/RKLS-1123)

## Description Of Changes

In this PR, I add a functionality to reply with a text message that contains a link

### Technical Approach

- Refactor `OGItemMessageBody`:
   - Add `onClickRepliedMessage` prop
   - Use `ClampedMessageItemBody` as the message body
   - Render `RepliedMessageItemBody`

### Additional Changes
- Add mocked OG message inside the `__mocks__/messagesMock`
- Update snapshot test of `OGMessageItemBody` to use the mocked message
- Update story of `OGMessageItemBody`to use the mocked message

### Demo

https://user-images.githubusercontent.com/24476578/141764687-edeb0a71-ecd0-4ec8-bd67-e2b6f508772c.mp4



