### PR TITLE
fix: add includeMetaArray param in each getMessagesByTimestamp call

### DIFF
--- a/src/rogu/smart-components/Conversation/hooks/useHandleReconnect.js
+++ b/src/rogu/smart-components/Conversation/hooks/useHandleReconnect.js
@@ -21,6 +21,7 @@ function useHandleReconnect({ isOnline }, {
 
         const messageListParams = new sdk.MessageListParams();
         messageListParams.prevResultSize = 30;
+        messageListParams.includeMetaArray = true;
         messageListParams.includeReplies = false;
         messageListParams.includeReaction = useReaction;
 

--- a/src/rogu/smart-components/Conversation/hooks/useScrollCallback.js
+++ b/src/rogu/smart-components/Conversation/hooks/useScrollCallback.js
@@ -16,6 +16,7 @@ function useScrollCallback({
     if (!hasMore) { return; }
     const messageListParams = new sdk.MessageListParams();
     messageListParams.prevResultSize = 30;
+    messageListParams.includeMetaArray = true;
     messageListParams.includeReplies = false;
     messageListParams.includeReaction = true;
 

--- a/src/rogu/smart-components/Conversation/hooks/useScrollDownCallback.js
+++ b/src/rogu/smart-components/Conversation/hooks/useScrollDownCallback.js
@@ -18,6 +18,7 @@ function useScrollDownCallback({
     if (!hasMoreToBottom) { return; }
     const messageListParams = new sdk.MessageListParams();
     messageListParams.nextResultSize = RESULT_SIZE;
+    messageListParams.includeMetaArray = true;
     messageListParams.includeReplies = false;
     messageListParams.includeReaction = true;
 


### PR DESCRIPTION
> This project is a forked version of the [Sendbird UI Kit](https://github.com/sendbird/sendbird-uikit-react) to match with the Ruangguru's internal requirements. Therefore, it is not yet set up to accept pull requests from external contributors. But you can always freely create a forked version from this repository to match your own requirements.

## Related Issue

[RKLS-1129](https://ruanggguru.atlassian.net/browse/RKLS-1129)

## Description Of Changes

In this PR, I fixed the unexpected behavior of replied messages upon scrolling:
- If the user scrolls up the chatroom screen and fetched previous messages, the replied message will not be displayed as expected 
- If the user scrolls down the chatroom screen and fetched the next messages, the replied message will not be displayed as expected 

https://user-images.githubusercontent.com/24476578/141871274-8d6e0f01-cbbe-4ff9-98d5-257ff3344af6.mp4



### Technical Approach

In the current implementation, we store a replied message data inside the `sorted_metaarray`. Somehow the `sorted_metaarray` is empty if message fetching is triggered via page scroll. 

The fetching mechanism happened via `groupChannel.getMessagesByTimestamp()` that called in a view places (e.g. `useScrollCallback`, `useScrollDownCallback`). The root cause of the empty `sorted_metaarray` is that the request params contains `with_sorted_meta_array=false`.

![Request Params - Before](https://user-images.githubusercontent.com/24476578/141872074-7a7be534-13f0-4203-a848-ea6e44dc0b82.png)

To fix that issue, we need to pass the `with_sorted_meta_array=true` as request params by adding `messageListParams.includeMetaArray=true` in every `groupChannel.getMessagesByTimestamp(messageListParams)`.

![Request Params - After](https://user-images.githubusercontent.com/24476578/141872420-505e5097-1298-4098-b486-68e6b77abe85.png)

### Additional Changes

Nope

### Demo

https://user-images.githubusercontent.com/24476578/141872435-c9002095-b20f-414d-ba21-2dc5d8090e76.mp4


