### PR TITLE
feat: copy the originalMessage only on replied message

### DIFF
--- a/src/rogu/ui/MessageItemMenu/index.tsx
+++ b/src/rogu/ui/MessageItemMenu/index.tsx
@@ -17,6 +17,8 @@ import Icon, { IconTypes, IconColors } from '../Icon';
 import ContextMenu, { MenuItems, MenuItem } from '../ContextMenu';
 import Toast from '../Toast';
 
+import {formatedStringToRepliedMessage} from '../../utils/repliedMessage';
+
 import './index.scss';
 
 interface Props {
@@ -85,8 +87,11 @@ export default function MessageItemMenu({
     return null;
   }
 
+  
+
   const onCopyClick = (message: string) => {
-    copyToClipboard(message);
+    const {originalMessage} = formatedStringToRepliedMessage(message);
+    copyToClipboard(originalMessage);
     setShowToast(true);
     setTimeout(() => {
       setShowToast(false);


### PR DESCRIPTION
> This project is a forked version of the [Sendbird UI Kit](https://github.com/sendbird/sendbird-uikit-react) to match with the Ruangguru's internal requirements. Therefore, it is not yet set up to accept pull requests from external contributors. But you can always freely create a forked version from this repository to match your own requirements.

## Related Issue

[<JIRA_CARD>](https://ruanggguru.atlassian.net/browse/<JIRA_CARD>)

## Description Of Changes

- [X] copy the originalMessage only on replied message
https://user-images.githubusercontent.com/5103456/140674527-04c0390e-8339-4dac-8753-c25d6ccf5121.mov
