### PR TITLE
fix: ensure that file and thumbnail content are not rendered simultaneously

### DIFF
--- a/src/rogu/ui/MessageContent/index.tsx
+++ b/src/rogu/ui/MessageContent/index.tsx
@@ -216,13 +216,6 @@ Props): ReactElement {
                   isByMe={isByMe}
                 />
               )}
-              {getUIKitMessageType(message as FileMessage) ===
-                messageTypes.FILE && (
-                <FileMessageItemBody
-                  message={message as FileMessage}
-                  isByMe={isByMe}
-                />
-              )}
               {isThumbnailMessage(message as FileMessage) && (
                 <ThumbnailMessageItemBody
                   message={message as FileMessage}
@@ -235,6 +228,14 @@ Props): ReactElement {
                   onClickRepliedMessage={scrollToMessage}
                 />
               )}
+              {!isThumbnailMessage(message as FileMessage) &&
+                getUIKitMessageType(message as FileMessage) ===
+                  messageTypes.FILE && (
+                  <FileMessageItemBody
+                    message={message as FileMessage}
+                    isByMe={isByMe}
+                  />
+                )}
               {getUIKitMessageType(message as FileMessage) ===
                 messageTypes.UNKNOWN && (
                 <UnknownMessageItemBody message={message} isByMe={isByMe} />

--- a/src/rogu/ui/ThumbnailMessageItemBody/index.tsx
+++ b/src/rogu/ui/ThumbnailMessageItemBody/index.tsx
@@ -6,8 +6,12 @@ import Icon, { IconTypes, IconColors } from '../Icon';
 import ImageRenderer from '../ImageRenderer';
 import RepliedMessageItemBody from '../RepliedMessageItemBody';
 import ClampedMessageItemBody from '../ClampedMessageItemBody';
-import { isReplyingMessage, metaArraysToRepliedMessage } from '../../utils';
-import { getClassName, isGifMessage, isVideoMessage } from '../../../utils';
+import {
+  isReplyingMessage,
+  isVideo,
+  metaArraysToRepliedMessage,
+} from '../../utils';
+import { getClassName, isGifMessage } from '../../../utils';
 
 interface Props {
   className?: string | Array<string>;
@@ -97,7 +101,7 @@ export default function ThumbnailMessageItemBody({
               <div className="rogu-thumbnail-message-item-body__placeholder__icon">
                 <Icon
                   type={
-                    isVideoMessage(message) ? IconTypes.PLAY : IconTypes.PHOTO
+                    isVideo(message.type) ? IconTypes.PLAY : IconTypes.PHOTO
                   }
                   fillColor={IconColors.ON_BACKGROUND_2}
                   width="34px"
@@ -107,17 +111,17 @@ export default function ThumbnailMessageItemBody({
             </div>
           )}
         />
-        {isVideoMessage(message) && !thumbnailUrl && (
+        {isVideo(message.type) && !thumbnailUrl && (
           <video className="rogu-thumbnail-message-item-body__video">
             <source src={message?.url} type={message?.type} />
           </video>
         )}
         <div className="rogu-thumbnail-message-item-body__image-cover" />
-        {(isVideoMessage(message) || isGifMessage(message)) && (
+        {(isVideo(message.type) || isGifMessage(message)) && (
           <div className="rogu-thumbnail-message-item-body__icon-wrapper">
             <div className="rogu-thumbnail-message-item-body__icon-wrapper__icon">
               <Icon
-                type={isVideoMessage(message) ? IconTypes.PLAY : IconTypes.GIF}
+                type={isVideo(message.type) ? IconTypes.PLAY : IconTypes.GIF}
                 fillColor={IconColors.ON_BACKGROUND_2}
                 width="34px"
                 height="34px"


### PR DESCRIPTION
> This project is a forked version of the [Sendbird UI Kit](https://github.com/sendbird/sendbird-uikit-react) to match with the Ruangguru's internal requirements. Therefore, it is not yet set up to accept pull requests from external contributors. But you can always freely create a forked version from this repository to match your own requirements.

## Related Issue

[RKLS-1081](https://ruanggguru.atlassian.net/browse/RKLS-1081)

## Description Of Changes

In this PR, I fix an unexpected behavior that the MOV file message will be displayed as a both file and thumbnail message

### Technical Approach

- The root cause of this issue is because MOV message is fulfilled the conditional for both thumbnail message and file message. To fix that, we add `!isThumbnailMessage` message on the message file conditional.
- Also notice that there should be a play icon on the thumbnail message. To fix that, we use `isVideo` util instead of `isVideoMessage` in `ThumbnailMessageItemBody`

### Additional Changes

Nope

### Demo

| Before (bug) | After (fixed) |
| ------------- | ------------- |
|  ![Screen Shot 2021-11-17 at 08 16 38](https://user-images.githubusercontent.com/24476578/142091562-593fd15c-3c18-4e06-9886-2aa3a42c5769.png) | ![Screen Shot 2021-11-17 at 08 10 26](https://user-images.githubusercontent.com/24476578/142091571-3d91621e-23d5-4ada-83c1-8cc07f42f5df.png) |


