### PR TITLE
fix: reply preview thumbnail shrinked when caption length is long

### DIFF
--- a/src/rogu/ui/ContextMenu/index.scss
+++ b/src/rogu/ui/ContextMenu/index.scss
@@ -1,4 +1,4 @@
-@import "../../../styles/variables";
+@import '../../../styles/variables';
 
 .rogu-dropdown__menu {
   z-index: $drawer;
@@ -41,6 +41,8 @@
 
     .rogu-dropdown__menu-item-icon {
       margin-right: 12px;
+      display: flex;
+      align-items: center;
     }
   }
 }

--- a/src/rogu/ui/RepliedMediaMessageItemBody/index.scss
+++ b/src/rogu/ui/RepliedMediaMessageItemBody/index.scss
@@ -30,11 +30,13 @@
   .rogu-media-message-item-body__metadata {
     display: flex;
 
-    .rogu-media-message-item-body__reply-image {
+    .rogu-media-message-item-body__reply-image,
+    .rogu-media-message-item-body__reply-video {
       margin-right: 8px;
       border-radius: 4px;
       width: 38px;
       height: 38px;
+      flex-shrink: 0;
     }
 
     .rogu-media-message-item-body__caption-container {

--- a/src/rogu/ui/RepliedMediaMessageItemBody/index.tsx
+++ b/src/rogu/ui/RepliedMediaMessageItemBody/index.tsx
@@ -64,7 +64,7 @@ export default function RepliedMediaMessageItemBody({
           />
         }
         {mediaUrl && isVideo(mimeType) &&
-          <video className="rogu-media-message-item-body__reply-image">
+          <video className="rogu-media-message-item-body__reply-video">
             <source src={mediaUrl} type={mimeType} />
           </video>
         }


### PR DESCRIPTION
> This project is a forked version of the [Sendbird UI Kit](https://github.com/sendbird/sendbird-uikit-react) to match with the Ruangguru's internal requirements. Therefore, it is not yet set up to accept pull requests from external contributors. But you can always freely create a forked version from this repository to match your own requirements.

## Related Issue

[RKLS-1146](https://ruanggguru.atlassian.net/browse/RKLS-1146)

## Description Of Changes

Fix reply preview thumbnail shrinked when caption length is long

## Additional changes
- Center `MenuItem` icon with its text

### Technical Approach
- Add `flex-shrink: 0` to the media preview

### Demo
### Before
Preview message input
![Screen Shot 2021-11-17 at 16 47 10](https://user-images.githubusercontent.com/26358930/142181693-24edb57f-bce5-4f39-bc7a-2f4c9893851d.png)

Message bubble
![Screen Shot 2021-11-17 at 16 47 21](https://user-images.githubusercontent.com/26358930/142181713-5900223a-710b-4a6d-bfe1-59c7f724909f.png)

Menu item
![Screen Shot 2021-11-17 at 16 45 23](https://user-images.githubusercontent.com/26358930/142184313-202cb7b9-592a-446c-9e21-09c5d7f41871.png)


### After
Preview message input
![Screen Shot 2021-11-17 at 16 46 48](https://user-images.githubusercontent.com/26358930/142181749-db8eed94-ac30-4df8-8ec7-5a487381c2b9.png)

Message bubble
![Screen Shot 2021-11-17 at 16 47 38](https://user-images.githubusercontent.com/26358930/142181765-edc5a95b-d6e1-43cf-a1c2-e24c90a142dc.png)

Menu item
![Screen Shot 2021-11-17 at 16 45 39](https://user-images.githubusercontent.com/26358930/142184351-2f763fe5-1467-49d4-900f-672df09e36f5.png)


