### PR TITLE
fix: remove line break character in replied message

### DIFF
--- a/src/rogu/ui/MessageInput/index.jsx
+++ b/src/rogu/ui/MessageInput/index.jsx
@@ -26,6 +26,7 @@ import {
   isReplyingMessage,
   isThumbnailMessage,
   isVideo,
+  REGEX_LINE_BREAK,
   REPLIED_MESSAGE_TYPE,
   SUPPORTED_MIMES,
 } from '../../utils';
@@ -190,7 +191,9 @@ const MessageInput = React.forwardRef((props, ref) => {
       modifiedFile.name = inputValue.slice(0, 930);
 
       if (repliedMessage) {
-        let repliedMessageBody = repliedMessage.message;
+        // Replace line break with space to avoid breaking the reply message workaround
+        let repliedMessageBody = repliedMessage.message?.replace(REGEX_LINE_BREAK, ' ');
+
         let repliedMessageMediaUrl = '';
         let repliedMessageMimeType = '*';
         let repliedMessageType = REPLIED_MESSAGE_TYPE.Text;
@@ -241,7 +244,9 @@ const MessageInput = React.forwardRef((props, ref) => {
       }
     } else if (inputValue && inputValue.trim().length > 0) {
       if (repliedMessage) {
-        let repliedMessageBody = repliedMessage.message;
+        // Replace line break with space to avoid breaking the reply message workaround
+        let repliedMessageBody = repliedMessage.message?.replace(REGEX_LINE_BREAK, ' ');
+
         let repliedMessageMediaUrl = '';
         let repliedMessageMimeType = '*';
         let repliedMessageType = REPLIED_MESSAGE_TYPE.Text;

--- a/src/rogu/utils/constants.ts
+++ b/src/rogu/utils/constants.ts
@@ -1,2 +1,5 @@
 export const META_ARRAY_VALUE_MAX_CHAR = 128;
 export const REPLIED_MESSAGE_QUOTE_FORMAT = '>';
+
+export const REGEX_LINE_BREAK = /\r?\n|\r/g;
+export const REGEX_URL = /[(http(s)?):\/\/(www\.)?a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*?)/g;

--- a/src/rogu/utils/url.ts
+++ b/src/rogu/utils/url.ts
@@ -1,4 +1,4 @@
-export const REGEX_URL = /[(http(s)?):\/\/(www\.)?a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*?)/g;
+import { REGEX_URL } from './constants';
 
 const K = '[[SPLIT_KEYWORD]]';
 export const extractUrls = (


### PR DESCRIPTION
> This project is a forked version of the [Sendbird UI Kit](https://github.com/sendbird/sendbird-uikit-react) to match with the Ruangguru's internal requirements. Therefore, it is not yet set up to accept pull requests from external contributors. But you can always freely create a forked version from this repository to match your own requirements.

## Related Issue

[RKLS-1150](https://ruanggguru.atlassian.net/browse/RKLS-1150)

## Description Of Changes

In this PR, I fix some unexpected behavior when replying to a message that contains a line break. Notice that the some part of the replied message will be displayed as the reply message:

https://user-images.githubusercontent.com/24476578/142371281-45abae70-408b-4d42-a387-72c9db0e6def.mp4

### Technical Approach

In the current implementation, we use some workaround that is compatible with the implementation in the mobile app. We store the replied message content inside the reply message using some special formatting:

```
> [Nickname] \n > [RepliedMessage] \n [MessageReply]
```

It would be problematic if the replied message contains a line break.

To fix that issue, I replace the line breaks in the replied message with spaces

### Additional Changes

Nope 

### Demo


https://user-images.githubusercontent.com/24476578/142374200-5b2df223-9992-4373-994b-273704eec596.mp4



