### PR TITLE
fix: trim the replied message

### DIFF
--- a/src/rogu/ui/MessageInput/index.jsx
+++ b/src/rogu/ui/MessageInput/index.jsx
@@ -26,7 +26,7 @@ import {
   isReplyingMessage,
   isThumbnailMessage,
   isVideo,
-  REGEX_LINE_BREAK,
+  normalizeRepliedMessageBody,
   REPLIED_MESSAGE_TYPE,
   SUPPORTED_MIMES,
 } from '../../utils';
@@ -191,8 +191,7 @@ const MessageInput = React.forwardRef((props, ref) => {
       modifiedFile.name = inputValue.slice(0, 930);
 
       if (repliedMessage) {
-        // Replace line break with space to avoid breaking the reply message workaround
-        let repliedMessageBody = repliedMessage.message?.replace(REGEX_LINE_BREAK, ' ');
+        let repliedMessageBody = normalizeRepliedMessageBody(repliedMessage.message || '');
 
         let repliedMessageMediaUrl = '';
         let repliedMessageMimeType = '*';
@@ -244,8 +243,7 @@ const MessageInput = React.forwardRef((props, ref) => {
       }
     } else if (inputValue && inputValue.trim().length > 0) {
       if (repliedMessage) {
-        // Replace line break with space to avoid breaking the reply message workaround
-        let repliedMessageBody = repliedMessage.message?.replace(REGEX_LINE_BREAK, ' ');
+        let repliedMessageBody = normalizeRepliedMessageBody(repliedMessage.message || '');
 
         let repliedMessageMediaUrl = '';
         let repliedMessageMimeType = '*';

--- a/src/rogu/ui/RepliedMediaMessageItemBody/index.scss
+++ b/src/rogu/ui/RepliedMediaMessageItemBody/index.scss
@@ -39,6 +39,16 @@
       flex-shrink: 0;
     }
 
+    .rogu-media-message-item-body__sender-name {
+      white-space: pre-wrap;
+      word-break: break-all;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      display: -webkit-box;
+      -webkit-line-clamp: 1;
+      -webkit-box-orient: vertical;
+    }
+
     .rogu-media-message-item-body__caption-container {
       display: flex;
       align-items: center;

--- a/src/rogu/ui/RepliedMediaMessageItemBody/index.tsx
+++ b/src/rogu/ui/RepliedMediaMessageItemBody/index.tsx
@@ -70,7 +70,7 @@ export default function RepliedMediaMessageItemBody({
         }
         <div>
           <Label
-            className="rogu-message-content__sender-name"
+            className="rogu-media-message-item-body__sender-name"
             color={LabelColors.ONBACKGROUND_2}
             style={{
               color: generateColorFromString(

--- a/src/rogu/utils/constants.ts
+++ b/src/rogu/utils/constants.ts
@@ -1,4 +1,5 @@
 export const META_ARRAY_VALUE_MAX_CHAR = 128;
+export const REPLIED_MESSAGE_MAX_CHAR = 200;
 export const REPLIED_MESSAGE_QUOTE_FORMAT = '>';
 
 export const REGEX_LINE_BREAK = /\r?\n|\r/g;

--- a/src/rogu/utils/repliedMessage.ts
+++ b/src/rogu/utils/repliedMessage.ts
@@ -3,6 +3,8 @@ import { MessageMetaArray, SendBirdInstance } from 'sendbird';
 import { CoreMessageType } from '../../utils';
 import {
   META_ARRAY_VALUE_MAX_CHAR,
+  REGEX_LINE_BREAK,
+  REPLIED_MESSAGE_MAX_CHAR,
   REPLIED_MESSAGE_QUOTE_FORMAT,
 } from './constants';
 
@@ -129,3 +131,10 @@ export const metaArraysToRepliedMessage = (
       parentMessageType: RepliedMessageType.Text,
     }
   );
+
+export const normalizeRepliedMessageBody = (messageBody: string): string =>
+  messageBody
+    // Remove line break (`\n`) to avoid breaking the replied message workaround
+    .replace(REGEX_LINE_BREAK, ' ')
+    // Trim the replied message body to ensure that the character length is below the limit
+    .substring(0, REPLIED_MESSAGE_MAX_CHAR);


### PR DESCRIPTION
> This project is a forked version of the [Sendbird UI Kit](https://github.com/sendbird/sendbird-uikit-react) to match with the Ruangguru's internal requirements. Therefore, it is not yet set up to accept pull requests from external contributors. But you can always freely create a forked version from this repository to match your own requirements.

## Related Issue

[RKLS-1154](https://ruanggguru.atlassian.net/browse/RKLS-1154)

## Description Of Changes

In this PR, I fix some unexpected behavior in the reply to a message feature that if we reply a long message with a long message, the message reply will be trimmed unexpectedly:


https://user-images.githubusercontent.com/24476578/142540914-bca13390-9972-4110-be7e-fcda53267ecb.mp4


### Technical Approach

In the current implementation, we use some workaround that is compatible with the implementation in the mobile app. We store the replied message (original message) inside the reply message using some special formatting:

```
> [Nickname] \n > [OriginalMessage] \n [ReplyMessage]
```

The Sendbird has 5000 character limit, while our web app has 3000 character limit. So it would be problematic if the sum of `Nickname` + `OriginalMessage` + `ReplyMessage` is more than 5000. 

To fix this issue, I trim the the `OriginalMessage` by 200 character. Since it will be displayed in maximum two rows ellipsis, it would be okay to do it that way.


### Additional Changes

Refine `RepliedMediaMessageItemBody`

### Demo

https://user-images.githubusercontent.com/24476578/142535332-f4819688-da5f-4c39-b7f3-5a7a07594299.mp4



