### PR TITLE
fix: make URL regex to include beyond URLs "port name"

### DIFF
--- a/src/rogu/utils/constants.ts
+++ b/src/rogu/utils/constants.ts
@@ -6,4 +6,5 @@ export const REGEX_LINE_BREAK = /\r?\n|\r/g;
 
 // Note: Source thread: https://stackoverflow.com/questions/3809401/what-is-a-good-regular-expression-to-match-a-url
 // Note: Source demo: https://regexr.com/3e6m0
-export const REGEX_URL = /(http(s)?:\/\/.)?(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)/g;
+export const REGEX_URL = /(http(s)?:\/\/.)?(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+~#?&//=]*)/g;
+// export const REGEX_URL = /[(http(s)?):\/\/(www\.)?a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*?)/g;

--- a/src/rogu/utils/constants.ts
+++ b/src/rogu/utils/constants.ts
@@ -3,4 +3,4 @@ export const REPLIED_MESSAGE_MAX_CHAR = 200;
 export const REPLIED_MESSAGE_QUOTE_FORMAT = '>';
 
 export const REGEX_LINE_BREAK = /\r?\n|\r/g;
-export const REGEX_URL = /[(http(s)?):\/\/(www\.)?a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*?)/g;
+export const REGEX_URL = /(http(s)?:\/\/.)?(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)/g;

--- a/src/rogu/utils/constants.ts
+++ b/src/rogu/utils/constants.ts
@@ -3,4 +3,7 @@ export const REPLIED_MESSAGE_MAX_CHAR = 200;
 export const REPLIED_MESSAGE_QUOTE_FORMAT = '>';
 
 export const REGEX_LINE_BREAK = /\r?\n|\r/g;
+
+// Note: Source thread: https://stackoverflow.com/questions/3809401/what-is-a-good-regular-expression-to-match-a-url
+// Note: Source demo: https://regexr.com/3e6m0
 export const REGEX_URL = /(http(s)?:\/\/.)?(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)/g;

--- a/src/rogu/utils/url.spec.js
+++ b/src/rogu/utils/url.spec.js
@@ -8,4 +8,10 @@ describe('utils/url', () => {
 
     expect(urls.length).toEqual(5);
   });
+
+  it('should not contain any trailling punctuations', () => {
+    const { urls, sentences } = extractUrls('aa.com.., bb.com!');
+
+    expect(urls).toEqual(expect.arrayContaining(['aa.com', 'bb.com']));
+  });
 });

--- a/src/rogu/utils/url.spec.js
+++ b/src/rogu/utils/url.spec.js
@@ -8,10 +8,4 @@ describe('utils/url', () => {
 
     expect(urls.length).toEqual(5);
   });
-
-  it('should not contain any trailling punctuations', () => {
-    const { urls, sentences } = extractUrls('aa.com.., bb.com!');
-
-    expect(urls).toEqual(expect.arrayContaining(['aa.com', 'bb.com']));
-  });
 });


### PR DESCRIPTION
> This project is a forked version of the [Sendbird UI Kit](https://github.com/sendbird/sendbird-uikit-react) to match with the Ruangguru's internal requirements. Therefore, it is not yet set up to accept pull requests from external contributors. But you can always freely create a forked version from this repository to match your own requirements.

## Related Issue

[RKLS-1195](https://ruanggguru.atlassian.net/browse/RKLS-1195)

## Description Of Changes

String after the URLs port name (the `.com`, etc) does not rendered as part of the link

### Technical Approach
- Change the regex for the URL
- Removes testing case which does not match the expected behavior

### Demo
### Before
![image](https://user-images.githubusercontent.com/26358930/143400615-6e24b0bb-fabe-46ea-a1f8-5c078c5ab09b.png)

### After
![image](https://user-images.githubusercontent.com/26358930/143400509-659154c4-8809-4e85-9b0f-ad566c0171a8.png)

![image](https://user-images.githubusercontent.com/26358930/143400543-63eb0c1a-3677-4c32-97a3-358e810f5171.png)