### PR TITLE
feat: Handle iOS webview link target

### DIFF
--- a/src/rogu/ui/AssignmentMessageItemBody/index.tsx
+++ b/src/rogu/ui/AssignmentMessageItemBody/index.tsx
@@ -3,12 +3,14 @@ import { UserMessage } from 'sendbird';
 
 import Label, { LabelTypography, LabelColors } from '../Label';
 import Icon, { IconTypes } from '../Icon';
-import {
-  getClassName,
-} from '../../../utils';
+import { getClassName } from '../../../utils';
 import { LocalizationContext } from '../../../lib/LocalizationContext';
-import {convertCtaLinkToWebLink, convertAssignmentDueUTCtoLocale} from '../../utils';
+import {
+  convertCtaLinkToWebLink,
+  convertAssignmentDueUTCtoLocale,
+} from '../../utils';
 import './index.scss';
+import { isIOSWebView } from '../../../utils/utils';
 
 interface Props {
   className?: string | Array<string>;
@@ -27,55 +29,73 @@ export default function AssignmentMessageItemBody({
   const assignmentData = JSON.parse(message?.data);
 
   const openAssignment = (): void => {
-    if (assignmentData?.ctaWeb && assignmentData?.ctaWeb.length > 0){
-      window.open(`${assignmentData?.ctaWeb}?from=chatroom`);
-    } else{
-      window.open(convertCtaLinkToWebLink(assignmentData?.cta, "assignment"));
+    const target = isIOSWebView() ? '_top' : '_blank';
+
+    if (assignmentData?.ctaWeb && assignmentData?.ctaWeb.length > 0) {
+      window.open(`${assignmentData?.ctaWeb}?from=chatroom`, target);
+    } else {
+      window.open(
+        convertCtaLinkToWebLink(assignmentData?.cta, 'assignment'),
+        target
+      );
     }
   };
- 
 
   return (
-    <div 
-    className={getClassName([
-      className,
-      'rogu-assignment-message-item-body',
-      isByMe ? 'rogu-assignment-message-item-body--outgoing' : 'rogu-assignment-message-item-body--incoming',
-      mouseHover ? 'mouse-hover' : '',
-      message?.reactions?.length > 0 ? 'reactions' : '',
-    ])}>
+    <div
+      className={getClassName([
+        className,
+        'rogu-assignment-message-item-body',
+        isByMe
+          ? 'rogu-assignment-message-item-body--outgoing'
+          : 'rogu-assignment-message-item-body--incoming',
+        mouseHover ? 'mouse-hover' : '',
+        message?.reactions?.length > 0 ? 'reactions' : '',
+      ])}
+    >
       <div
         role="button"
         tabIndex={0}
         className="rogu-assignment-message-item-body__container"
         onClick={openAssignment}
-        onKeyPress={openAssignment}>
+        onKeyPress={openAssignment}
+      >
         <Icon
-            className="rogu-assignment-message-item-body__icon"
-            type={IconTypes.ROGU_ASSIGNMENT}
-            width="30"
-            height="30"
-          />
+          className="rogu-assignment-message-item-body__icon"
+          type={IconTypes.ROGU_ASSIGNMENT}
+          width="30"
+          height="30"
+        />
         <div className="rogu-assignment-message-item-body__text-container">
-          <Label className="rogu-assignment-message-item-body__text-title" color={LabelColors.ONBACKGROUND_1} type={LabelTypography.SUBTITLE_2}>
+          <Label
+            className="rogu-assignment-message-item-body__text-title"
+            color={LabelColors.ONBACKGROUND_1}
+            type={LabelTypography.SUBTITLE_2}
+          >
             {assignmentData?.title}
           </Label>
           <div>
-            <Label color={LabelColors.ONBACKGROUND_2} type={LabelTypography.BODY_2}>
+            <Label
+              color={LabelColors.ONBACKGROUND_2}
+              type={LabelTypography.BODY_2}
+            >
               {stringSet.ASSIGNMENT}
             </Label>
-            
-            {
-              assignmentData?.dueAt && assignmentData?.dueAt.length > 0 && <Label className="rogu-assignment-message-item-body__text-deadline" color={LabelColors.ONBACKGROUND_2} type={LabelTypography.BODY_2}>
-                
-              {stringSet.ASSIGNMENT_DEADLINE + " "+ convertAssignmentDueUTCtoLocale(assignmentData?.dueAt)}
-             
-            </Label>
-            }
+
+            {assignmentData?.dueAt && assignmentData?.dueAt.length > 0 && (
+              <Label
+                className="rogu-assignment-message-item-body__text-deadline"
+                color={LabelColors.ONBACKGROUND_2}
+                type={LabelTypography.BODY_2}
+              >
+                {stringSet.ASSIGNMENT_DEADLINE +
+                  ' ' +
+                  convertAssignmentDueUTCtoLocale(assignmentData?.dueAt)}
+              </Label>
+            )}
           </div>
         </div>
       </div>
-     
     </div>
   );
 }

--- a/src/rogu/ui/FileMessageItemBody/index.tsx
+++ b/src/rogu/ui/FileMessageItemBody/index.tsx
@@ -7,6 +7,7 @@ import Icon, { IconTypes, IconColors } from '../Icon';
 import { getClassName } from '../../../utils';
 import { LocalizationContext } from '../../../lib/LocalizationContext';
 import { formatBytes, getFileType, getMimeExtension } from '../../utils';
+import { isIOSWebView } from '../../../utils/utils';
 
 interface Props {
   className?: string | Array<string>;
@@ -20,6 +21,7 @@ export default function FileMessageItemBody({
   isByMe = false,
 }: Props): ReactElement {
   const { stringSet } = useContext(LocalizationContext);
+  const target = isIOSWebView() ? '_top' : '_blank';
 
   return (
     <a
@@ -31,7 +33,7 @@ export default function FileMessageItemBody({
           : 'rogu-file-message-item-body--incoming',
       ])}
       href={message.plainUrl}
-      target="_blank"
+      target={target}
       rel="noreferrer"
     >
       <Icon

--- a/src/rogu/ui/LinkLabel/index.jsx
+++ b/src/rogu/ui/LinkLabel/index.jsx
@@ -4,13 +4,13 @@ import PropTypes from 'prop-types';
 import Label, { LabelTypography, LabelColors } from '../Label';
 import { changeColorToClassName } from '../Label/utils';
 import './index.scss';
+import { isIOSWebView } from '../../../utils/utils';
 
 const http = /https?:\/\//;
 
-export default function LinkLabel({
-  className, src, type, color, children,
-}) {
+export default function LinkLabel({ className, src, type, color, children }) {
   const url = http.test(src) ? src : `http://${src}`;
+  const target = isIOSWebView() ? '_top' : '_blank';
 
   return (
     <a
@@ -20,7 +20,7 @@ export default function LinkLabel({
         color ? changeColorToClassName(color) : '',
       ].join(' ')}
       href={url}
-      target="_blank"
+      target={target}
       rel="noopener noreferrer"
     >
       <Label className="rogu-link-label__label" type={type} color={color}>

--- a/src/rogu/ui/MaterialMessageItemBody/index.tsx
+++ b/src/rogu/ui/MaterialMessageItemBody/index.tsx
@@ -1,12 +1,13 @@
-import React, { ReactElement, useContext } from "react";
-import { UserMessage } from "sendbird";
-import "./index.scss";
+import React, { ReactElement, useContext } from 'react';
+import { UserMessage } from 'sendbird';
+import './index.scss';
 
-import Label, { LabelTypography, LabelColors } from "../Label";
-import { getClassName } from "../../../utils";
+import Label, { LabelTypography, LabelColors } from '../Label';
+import { getClassName } from '../../../utils';
 import { LocalizationContext } from '../../../lib/LocalizationContext';
 import Icon, { IconTypes } from '../Icon';
-import { convertCtaLinkToWebLink } from "../../utils";
+import { convertCtaLinkToWebLink } from '../../utils';
+import { isIOSWebView } from '../../../utils/utils';
 
 interface Props {
   className?: string | Array<string>;
@@ -23,35 +24,52 @@ export default function MaterialMessageItemBody({
   const materialData = JSON.parse(message?.data);
 
   const openMaterial = (): void => {
-    if (materialData?.ctaWeb && materialData?.ctaWeb.length > 0){
-      window.open(`${materialData?.ctaWeb}?from=chatroom`);
-    } else{
-      window.open(convertCtaLinkToWebLink(materialData?.cta, "material"));
+    const target = isIOSWebView() ? '_top' : '_blank';
+
+    if (materialData?.ctaWeb && materialData?.ctaWeb.length > 0) {
+      window.open(`${materialData?.ctaWeb}?from=chatroom`, target);
+    } else {
+      window.open(
+        convertCtaLinkToWebLink(materialData?.cta, 'material'),
+        target
+      );
     }
   };
   return (
-    <div className={getClassName([
-      className, 
-      "rogu-material-message-item-body", 
-      isByMe ? 'rogu-material-message-item-body--outgoing' : 'rogu-material-message-item-body--incoming', 
-      message?.reactions?.length > 0 ? 'reactions' : '',
-      ])}>
+    <div
+      className={getClassName([
+        className,
+        'rogu-material-message-item-body',
+        isByMe
+          ? 'rogu-material-message-item-body--outgoing'
+          : 'rogu-material-message-item-body--incoming',
+        message?.reactions?.length > 0 ? 'reactions' : '',
+      ])}
+    >
       <div
         className="rogu-material-message-item-body__container"
-        onClick={openMaterial}>
+        onClick={openMaterial}
+      >
         <Icon
-            className="rogu-material-message-item-body__icon"
-            type={IconTypes.ROGU_MATERIAL}
-            width="30"
-            height="30"
-          />
+          className="rogu-material-message-item-body__icon"
+          type={IconTypes.ROGU_MATERIAL}
+          width="30"
+          height="30"
+        />
         <div className="rogu-material-message-item-body__text-container">
-          <Label className="rogu-material-message-item-body__text-title" color={LabelColors.ONBACKGROUND_1} type={LabelTypography.SUBTITLE_2}>
+          <Label
+            className="rogu-material-message-item-body__text-title"
+            color={LabelColors.ONBACKGROUND_1}
+            type={LabelTypography.SUBTITLE_2}
+          >
             {materialData?.title}
           </Label>
-          <Label color={LabelColors.ONBACKGROUND_2} type={LabelTypography.BODY_2}>
+          <Label
+            color={LabelColors.ONBACKGROUND_2}
+            type={LabelTypography.BODY_2}
+          >
             {stringSet.MATERIAL}
-          </Label>  
+          </Label>
         </div>
       </div>
     </div>

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -4,17 +4,15 @@ export const noop = () => {};
 
 export const getMessageCreatedAt = (message) => format(message.createdAt, 'p');
 
-export const getSenderName = (message) =>
-  message.sender &&
-  (message.sender.friendName ||
-    message.sender.nickname ||
-    message.sender.userId);
+export const getSenderName = (message) => message.sender
+  && (message.sender.friendName
+    || message.sender.nickname
+    || message.sender.userId);
 
 export const isIOSWebView = () => {
   let checkIOSWebView = false;
 
-  const platform =
-    navigator?.userAgentData?.platform || navigator?.platform || 'unknown';
+  const platform = navigator?.userAgentData?.platform || navigator?.platform || 'unknown';
 
   if (platform.substr(0, 2) === 'iP') {
     // iOS (iPhone, iPod or iPad)
@@ -24,9 +22,9 @@ export const isIOSWebView = () => {
     const idb = !!window.indexedDB;
 
     if (
-      ua.indexOf('Safari') !== -1 &&
-      ua.indexOf('Version') !== -1 &&
-      !nav.standalone
+      ua.indexOf('Safari') !== -1
+      && ua.indexOf('Version') !== -1
+      && !nav.standalone
     ) {
       // Safari (WKWebView/Nitro since 6+)
       checkIOSWebView = false;
@@ -34,20 +32,19 @@ export const isIOSWebView = () => {
       // UIWebView
       checkIOSWebView = true;
     } else if (
-      (window.webkit && window.webkit.messageHandlers) ||
-      !lte9 ||
-      idb
+      (window.webkit && window.webkit.messageHandlers)
+      || !lte9
+      || idb
     ) {
       // WKWebView
       checkIOSWebView = true;
     }
   }
-  console.log('checkIOSWebView', checkIOSWebView);
+
   return checkIOSWebView;
 };
 
-export const getSenderProfileUrl = (message) =>
-  message.sender && message.sender.profileUrl;
+export const getSenderProfileUrl = (message) => message.sender && message.sender.profileUrl;
 
 export default {
   getMessageCreatedAt,

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -4,15 +4,50 @@ export const noop = () => {};
 
 export const getMessageCreatedAt = (message) => format(message.createdAt, 'p');
 
-export const getSenderName = (message) => (
-  message.sender && (
-    message.sender.friendName
-    || message.sender.nickname
-    || message.sender.userId
-  )
-);
+export const getSenderName = (message) =>
+  message.sender &&
+  (message.sender.friendName ||
+    message.sender.nickname ||
+    message.sender.userId);
 
-export const getSenderProfileUrl = (message) => message.sender && message.sender.profileUrl;
+export const isIOSWebView = () => {
+  let checkIOSWebView = false;
+
+  const platform =
+    navigator?.userAgentData?.platform || navigator?.platform || 'unknown';
+
+  if (platform.substr(0, 2) === 'iP') {
+    // iOS (iPhone, iPod or iPad)
+    const lte9 = /constructor/i.test(window.HTMLElement);
+    const nav = window.navigator;
+    const ua = nav.userAgent;
+    const idb = !!window.indexedDB;
+
+    if (
+      ua.indexOf('Safari') !== -1 &&
+      ua.indexOf('Version') !== -1 &&
+      !nav.standalone
+    ) {
+      // Safari (WKWebView/Nitro since 6+)
+      checkIOSWebView = false;
+    } else if ((!idb && lte9) || !window.statusbar.visible) {
+      // UIWebView
+      checkIOSWebView = true;
+    } else if (
+      (window.webkit && window.webkit.messageHandlers) ||
+      !lte9 ||
+      idb
+    ) {
+      // WKWebView
+      checkIOSWebView = true;
+    }
+  }
+  console.log('checkIOSWebView', checkIOSWebView);
+  return checkIOSWebView;
+};
+
+export const getSenderProfileUrl = (message) =>
+  message.sender && message.sender.profileUrl;
 
 export default {
   getMessageCreatedAt,


### PR DESCRIPTION
> This project is a forked version of the [Sendbird UI Kit](https://github.com/sendbird/sendbird-uikit-react) to match with the Ruangguru's internal requirements. Therefore, it is not yet set up to accept pull requests from external contributors. But you can always freely create a forked version from this repository to match your own requirements.

## Related Issue

[RKLS-1941](https://ruanggguru.atlassian.net/browse/RKLS-1941)

## Description Of Changes

Add `target` condition to used `a` tag and `window.open`, `_top` instead of `_blank` if the chatroom is opened in iOS webview

### Technical Approach
Add `isIOSWebview` utils, the same as in `lms-web`

### Demo
Demo will be from `lms-web`

