### PR TITLE
release: v1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [1.2.1](Apr 22 2022)
+## [1.2.1](Apr 29 2022)
 
 - Feature
   - Add copy-css.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
-## [1.2.0](Apr 20 2022)
+## [1.2.1](Apr 22 2022)
+
+- Feature
+  - Add copy-css.sh
+
+## [1.2.0](Apr 29 2022)
 
 - Feature
   - Sync with upstream sendbird-uikit-react, release v2.7.0 (#93)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [1.2.1](Apr 29 2022)
 
-- Feature
+- Chore
   - Add copy-css.sh
 
 ## [1.2.0](Apr 29 2022)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [2.0.0](Apr 20 2022)
+
+- Feature
+  - Sync with upstream sendbird-uikit-react, release v2.7.0 (#93)
+
 ## [1.1.0](Apr 20 2022)
 
 - Feature

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Changelog
 
-## [2.0.0](Apr 20 2022)
+## [1.2.0](Apr 20 2022)
 
 - Feature
   - Sync with upstream sendbird-uikit-react, release v2.7.0 (#93)
+  - Bump sendbird v3.1.4
 
 ## [1.1.0](Apr 20 2022)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sendbird-uikit",
-  "version": "2.0.0",
+  "version": "1.2.0",
   "description": "React based UI kit for sendbird",
   "main": "release/index.js",
   "style": "release/dist/index.css",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sendbird-uikit",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "description": "React based UI kit for sendbird",
   "main": "release/index.js",
   "style": "release/dist/index.css",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sendbird-uikit",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "React based UI kit for sendbird",
   "main": "release/index.js",
   "style": "release/dist/index.css",

--- a/scripts/copy-css.sh
+++ b/scripts/copy-css.sh
@@ -1,0 +1,5 @@
+# to do: index.css cannot be bundled into ./dist using rollup.json
+# Also, rollup-copy is not working synchronously
+# Solution - for v3, we should change the bundling position/import of CSS
+mkdir dist
+cp ./release/dist/index.css ./dist/index.css


### PR DESCRIPTION
> This project is a forked version of the [Sendbird UI Kit](https://github.com/sendbird/sendbird-uikit-react) to match with the Ruangguru's internal requirements. Therefore, it is not yet set up to accept pull requests from external contributors. But you can always freely create a forked version from this repository to match your own requirements.

Release  `v1.2.1` with added `copy-css.sh`

- [x] PR title `release:1.2.1`
- [x] Add release 1.2.1 in `changelog`
- [x] Edit version in `package.json` to `1.2.1`
- [x] Add `release` labels in PR