### PR TITLE
chore: omit cp-css script

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,9 +18,8 @@
   "scripts": {
     "test": "jest",
     "test-update-snapshot": "jest -u",
-    "cp-css": "./scripts/copy-css.sh",
     "clean-release": "rm -rf ./release; rm -rf ./dist",
-    "build": "npm run clean-release; rollup -c; npm run cp-css",
+    "build": "npm run clean-release; rollup -c",
     "start": "rollup -c -w",
     "prepublishOnly": "npm run build",
     "predeploy": "cd example && npm install && npm run build",

--- a/scripts/copy-css.sh
+++ b/scripts/copy-css.sh
@@ -1,5 +1,0 @@
-# to do: index.css cannot be bundled into ./dist using rollup.json
-# Also, rollup-copy is not working synchronously
-# Solution - for v3, we should change the bundling position/import of CSS
-mkdir dist
-cp ./release/dist/index.css ./dist/index.css


### PR DESCRIPTION
> This project is a forked version of the [Sendbird UI Kit](https://github.com/sendbird/sendbird-uikit-react) to match with the Ruangguru's internal requirements. Therefore, it is not yet set up to accept pull requests from external contributors. But you can always freely create a forked version from this repository to match your own requirements.

## Description
Delete copy css script